### PR TITLE
Up/down buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ To change this property, define `spacing` on `sortable-item` (default is `0`):
 {{#sortable-item tagName="li" group=group spacing=15}}
 ```
 
+### Changing the drag tolerance
+
+`distance` attribute changes the tolerance, in pixels, for when sorting should start.
+If specified, sorting will not start until after mouse is dragged beyond distance.
+Can be used to allow for clicks on elements within a handle.
+
+```hbs
+{{#sortable-item group=group distance=30}}
+```
+
 ### CSS, Animation
 
 Sortable items can be in one of three states: default, dragging, dropping.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Ember Observer Score](http://emberobserver.com/badges/ember-sortable.svg)](http://emberobserver.com/addons/ember-sortable)
 [![Build Status](https://travis-ci.org/jgwhite/ember-sortable.svg?branch=master)](https://travis-ci.org/jgwhite/ember-sortable)
 [![Code Climate](https://codeclimate.com/github/jgwhite/ember-sortable/badges/gpa.svg)](https://codeclimate.com/github/jgwhite/ember-sortable)
+![Ember Version](https://embadge.io/v1/badge.svg?start=1.13.0)
 
 Sortable UI primitives for Ember.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ To change this property, define `spacing` on `sortable-item` (default is `0`):
 {{#sortable-item tagName="li" group=group spacing=15}}
 ```
 
+### Adding up/down buttons 
+
+`{{sortable-item}}` yields hash with two actions: `moveUp` and `moveDown`. Here is how you can use them:
+
+```hbs
+{{#sortable-group onChange="reorderItems" as |group|}}
+  {{#each model.items as |item|}}
+    {{#sortable-item tagName="li" model=item group=group handle=".handle" as |sortItem|}}
+      {{item.name}}
+      <button onclick={{sortItem.moveUp}}>&uarr;</button>
+      <button onclick={{sortItem.moveDown}}>&darr;</button>
+      <span class="handle">&varr;</span>
+    {{/sortable-item}}
+  {{/each}}
+{{/sortable-group}}
+```
+
 ### Changing the drag tolerance
 
 `distance` attribute changes the tolerance, in pixels, for when sorting should start.

--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/sortable-group';
-import computed from 'ember-new-computed';
+import computed from 'ember-computed';
 import {invokeAction} from 'ember-invoke-action';
 
 const { A, Component, get, set, run } = Ember;

--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -7,37 +7,53 @@ const { A, Component, get, set, run } = Ember;
 const a = A;
 const NO_MODEL = {};
 
+/**
+ * @module ember-sortable
+ * @class SortableGroup
+ * @extends Ember.Component
+ */
 export default Component.extend({
   layout: layout,
 
   attributeBindings: ['data-test-selector'],
 
   /**
-    @property direction
-    @type string
-    @default y
-  */
+   * Direction this group can be sorted in. Can be either 'y' or 'x'
+   *
+   * @property direction
+   * @type string
+   * @default y
+   * @public
+   */
   direction: 'y',
 
   /**
-    @property model
-    @type Any
-    @default null
-  */
+   * Optional "group model" to set. If this property is set,
+   * it will be passed in as the first argument to the
+   * {{#crossLink "SortableGroup/onChange:property"}}onChange action{{/crossLink}}
+   *
+   * @property model
+   * @type Any
+   * @default null
+   * @public
+   */
   model: NO_MODEL,
 
   /**
-    @property items
-    @type Ember.NativeArray
-  */
+   * @type Ember.NativeArray
+   * @property items
+   * @public
+   */
   items: computed(() => a()),
 
   /**
-    Position for the first item.
-    If spacing is present, first item's position will have to change as well.
-    @property itemPosition
-    @type Number
-  */
+   * Position for the first item.
+   * If spacing is present, first item's position will have to change as well.
+   *
+   * @property itemPosition
+   * @type Number
+   * @public
+   */
   itemPosition: computed(function() {
     let direction = this.get('direction');
 
@@ -45,9 +61,12 @@ export default Component.extend({
   }).volatile(),
 
   /**
-    @property sortedItems
-    @type Array
-  */
+   * List of items sorted by direction.
+   *
+   * @property sortedItems
+   * @type Array
+   * @public
+   */
   sortedItems: computed(function() {
     let items = a(this.get('items'));
     let direction = this.get('direction');
@@ -56,37 +75,45 @@ export default Component.extend({
   }).volatile(),
 
   /**
-    Register an item with this group.
-    @method registerItem
-    @param {SortableItem} [item]
-  */
+   * Register an item with this group.
+   *
+   * @method registerItem
+   * @param {SortableItem} item
+   * @public
+   */
   registerItem(item) {
     this.get('items').addObject(item);
   },
 
   /**
-    De-register an item with this group.
-    @method deregisterItem
-    @param {SortableItem} [item]
-  */
+   * De-register an item with this group.
+   *
+   * @method deregisterItem
+   * @param {SortableItem} item
+   * @public
+   */
   deregisterItem(item) {
     this.get('items').removeObject(item);
   },
 
   /**
-    Prepare for sorting.
-    Main purpose is to stash the current itemPosition so
-    we don’t incur expensive re-layouts.
-    @method prepare
-  */
+   * Prepare for sorting.
+   * Main purpose is to stash the current itemPosition so
+   * we don’t incur expensive re-layouts.
+   *
+   * @method prepare
+   * @public
+   */
   prepare() {
     this._itemPosition = this.get('itemPosition');
   },
 
   /**
-    Update item positions (relatively to the first element position).
-    @method update
-  */
+   * Update item positions (relative to the first element position).
+   *
+   * @method update
+   * @public
+   */
   update() {
     let sortedItems = this.get('sortedItems');
     // Position of the first element
@@ -122,8 +149,11 @@ export default Component.extend({
   },
 
   /**
-    @method commit
-  */
+   * Commit the state of dragged items
+   *
+   * @method commit
+   * @public
+   */
   commit() {
     let items = this.get('sortedItems');
     let groupModel = this.get('model');
@@ -158,4 +188,12 @@ export default Component.extend({
       invokeAction(this, 'onChange', itemModels, draggedModel);
     }
   }
+
+  /**
+   * String name or action function to call whenever the sort order changes.
+   *
+   * @event onChange
+   * @type Action|String
+   * @public
+   */
 });

--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -2,6 +2,15 @@ import Ember from 'ember';
 import layout from '../templates/components/sortable-item';
 import SortableItemMixin from '../mixins/sortable-item';
 
+/**
+ * Basic Ember component that uses the
+ * {{#crossLink "SortableItemMixin"}}{{/crossLink}}
+ *
+ * @module ember-sortable
+ * @class SortableItem
+ * @extends Ember.Component
+ * @uses SortableItemMixin
+ */
 export default Ember.Component.extend(SortableItemMixin, {
   layout
 });

--- a/addon/helpers/drag.js
+++ b/addon/helpers/drag.js
@@ -2,30 +2,29 @@ import Ember from 'ember';
 const { $ } = Ember;
 
 /**
-  Drags elements by an offset specified in pixels.
+ * Drags elements by an offset specified in pixels.
+ * Example:
+ *
 
-  Examples
+```js
+drag(
+  'mouse',
+  '.some-list li[data-item=uno]',
+  function() {
+    return { dy: 50, dx: 20 };
+  }
+);
+```
 
-      drag(
-        'mouse',
-        '.some-list li[data-item=uno]',
-        function() {
-          return { dy: 50, dx: 20 };
-        }
-      );
-
-  @method drag
-  @param {'mouse'|'touch'} [mode]
-    event mode
-  @param {String} [itemSelector]
-    selector for the element to drag
-  @param {Function} [offsetFn]
-    function returning the offset by which to drag
-  @param {Object} [callbacks]
-    callbacks that are fired at the different stages of the interaction
-  @return {Promise}
-*/
-
+ * @method drag
+ * @param {Ember.Application} app
+ * @param {'mouse'|'touch'} mode event mode
+ * @param {String} itemSelector selector for the element to drag
+ * @param {Function} offsetFn function returning the offset by which to drag
+ * @param {Object} callbacks callbacks that are fired at the different stages of the interaction
+ *
+ * @return {Promise}
+ */
 export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
   let start, move, end, which;
 

--- a/addon/helpers/drag.js
+++ b/addon/helpers/drag.js
@@ -54,6 +54,8 @@ export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
     let itemElement = item.get(0);
     let rect = itemElement.getBoundingClientRect();
     let scale = itemElement.clientHeight / (rect.bottom - rect.top);
+    let halfwayX = itemOffset.left + (offset.dx * scale) / 2;
+    let halfwayY = itemOffset.top + (offset.dy * scale) / 2;
     let targetX = itemOffset.left + offset.dx * scale;
     let targetY = itemOffset.top + offset.dy * scale;
 
@@ -75,6 +77,11 @@ export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
     if (callbacks.dragmove) {
       andThen(callbacks.dragmove);
     }
+
+    triggerEvent(app, item, move, {
+      pageX: halfwayX,
+      pageY: halfwayY
+    });
 
     triggerEvent(app, item, move, {
       pageX: targetX,

--- a/addon/helpers/reorder.js
+++ b/addon/helpers/reorder.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-/**
+/*
   In tests, the dummy app is rendered at half size.
   To avoid rounding errors, we must therefore double
   the overshoot.
@@ -8,28 +8,27 @@ import Ember from 'ember';
 const OVERSHOOT = 2;
 
 /**
-  Reorders elements to the specified state.
+ * Reorders elements to the specified state.
+ *
+ * Example:
 
-  Examples
-
-      reorder(
-        'mouse',
-        '.some-list li',
-        '[data-id="66278893"]',
-        '[data-id="66278894"]',
-        '[data-id="66278892"]'
-      );
-
-  @method reorder
-  @param {'mouse'|'touch'} [mode]
-    event mode
-  @param {String} [itemSelector]
-    selector for all items
-  @param {...String} [resultSelectors]
-    selectors for the resultant order
-  @return {Promise}
-*/
-
+```js
+reorder(
+  'mouse',
+  '.some-list li',
+  '[data-id="66278893"]',
+  '[data-id="66278894"]',
+  '[data-id="66278892"]'
+);
+```
+ * @method reorder
+ * @public
+ * @param {Ember.Application} app
+ * @param {'mouse'|'touch'} mode event mode
+ * @param {String} itemSelector selector for all items
+ * @param {String} [...resultSelectors] selectors for the resultant order
+ * @return {Promise}
+ */
 export function reorder(app, mode, itemSelector, ...resultSelectors) {
   const {
     andThen,

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -269,6 +269,11 @@ export default Mixin.create({
     // scheduled to prevent deprecation warning:
     // "never change properties on components, services or models during didInsertElement because it causes significant performance degradation"
     run.schedule("afterRender", this, "_tellGroup", "registerItem", this);
+
+    // Instead of using `event.preventDefault()` in the 'primeDrag' event,
+    // (doesn't work in Chrome 56), we set touch-action: none as a workaround.
+    let element = this.get('handle') ? this.$(this.get('handle')) : this.$();
+    element.css({ 'touch-action': 'none' });
   },
 
   willDestroyElement() {
@@ -350,9 +355,6 @@ export default Mixin.create({
     if (handle && !$(event.target).closest(handle).length) {
       return;
     }
-
-    event.preventDefault();
-    event.stopPropagation();
 
     this._startDragListener = event => this._startDrag(event);
 

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -7,7 +7,7 @@ import scrollParent from '../system/scroll-parent';
 import ScrollContainer from '../system/scroll-container';
 import {getX, getY, getBorderSpacing} from '../system/utils';
 
-const { Mixin, $, run } = Ember;
+const { Mixin, $, run, run: { bind } } = Ember;
 const { Promise } = Ember.RSVP;
 
 /**
@@ -50,6 +50,18 @@ export default Mixin.create({
    * @default null
    */
   handle: null,
+
+  /**
+   * Tolerance, in pixels, for when sorting should start.
+   * If specified, sorting will not start until after mouse
+   * is dragged beyond distance. Can be used to allow for clicks
+   * on elements within a handle.
+   *
+   * @property distance
+   * @type Integer
+   * @default 0
+   */
+  distance: 0,
 
   /**
    * True if the item is currently being dragged.
@@ -349,21 +361,40 @@ export default Mixin.create({
    * @param {Event} event JS Event object
    * @private
    */
-  _primeDrag(event) {
+  _primeDrag(startEvent) {
     let handle = this.get('handle');
 
-    if (handle && !$(event.target).closest(handle).length) {
+    if (handle && !$(startEvent.target).closest(handle).length) {
       return;
     }
 
-    this._startDragListener = event => this._startDrag(event);
+    this._prepareDragListener = bind(this, this._prepareDrag, startEvent);
 
     this._cancelStartDragListener = () => {
-      $(window).off('mousemove touchmove', this._startDragListener);
+      $(window).off('mousemove touchmove', this._prepareDragListener);
     };
 
-    $(window).one('mousemove touchmove', this._startDragListener);
+    $(window).on('mousemove touchmove', this._prepareDragListener);
     $(window).one('click mouseup touchend', this._cancelStartDragListener);
+  },
+
+  /**
+   * Prepares for the drag event
+   *
+   * @method _prepareDrag
+   * @param {Event} event JS Event object
+   * @param {Event} event JS Event object
+   * @private
+   */
+  _prepareDrag(startEvent, event) {
+    let distance = this.get('distance');
+    let dx = Math.abs(getX(startEvent) - getX(event));
+    let dy = Math.abs(getY(startEvent) - getY(event));
+
+    if (distance <= dx || distance <= dy) {
+      $(window).off('mousemove touchmove', this._prepareDragListener);
+      this._startDrag(startEvent);
+    }
   },
 
   /**

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -256,6 +256,21 @@ export default Mixin.create({
     return height;
   }).volatile(),
 
+  /**
+   * Hash with actions to {{yield}}.
+   *
+   * @property
+   * @type Object
+   * @protected
+   */
+  _actionsHash: computed(function() {
+    return {
+      moveUp:  this._move.bind(this, -1),
+      moveDown:  this._move.bind(this, +1),
+    };
+  }),
+
+
   /* Events */
 
   /**
@@ -631,7 +646,7 @@ export default Mixin.create({
     if(this.get('isDestroyed') || this.get('isDestroying')){
       return;
     }
-    
+
     let updateInterval = this.get('updateInterval');
     const groupDirection = this.get('group.direction');
 
@@ -709,10 +724,36 @@ export default Mixin.create({
     if(this.get('isDestroyed') || this.get('isDestroying')){
       return;
     }
-    
+
     invokeAction(this, 'onDragStop', this.get('model'));
     this.set('isDropping', false);
     this.set('wasDropped', true);
     this._tellGroup('commit');
-  }
+  },
+
+  /**
+   * Method used to move item one step up or down
+   *
+   * @method _move
+   * @param {Number|Direction} one for moving down (or right) -1 for opposite
+   * @private
+   */
+  _move(delta){
+    let sortedItems = this.get('group.sortedItems');
+    let thisIndex = sortedItems.indexOf(this);
+
+    if (thisIndex === 0 && delta < 0) {
+      return;
+    }
+
+    if(thisIndex === (sortedItems.length - 1) && delta > 0 ) {
+      return;
+    }
+
+    const swapItem = sortedItems[thisIndex + delta];
+    swapItem.set('index', swapItem.get('index') - delta);
+    this.set('index', this.get('index') + delta);
+
+    this._tellGroup('commit');
+  },
 });

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -628,6 +628,10 @@ export default Mixin.create({
    * @private
    */
   _drag(dimension) {
+    if(this.get('isDestroyed') || this.get('isDestroying')){
+      return;
+    }
+    
     let updateInterval = this.get('updateInterval');
     const groupDirection = this.get('group.direction');
 
@@ -702,6 +706,10 @@ export default Mixin.create({
    * @private
    */
   _complete() {
+    if(this.get('isDestroyed') || this.get('isDestroying')){
+      return;
+    }
+    
     invokeAction(this, 'onDragStop', this.get('model'));
     this.set('isDropping', false);
     this.set('wasDropped', true);

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-new-computed';
+import computed from 'ember-computed';
 import {invokeAction} from 'ember-invoke-action';
 import {throttle} from 'ember-runloop';
 

--- a/addon/system/utils.js
+++ b/addon/system/utils.js
@@ -1,0 +1,70 @@
+import Ember from 'ember';
+
+const {$} = Ember;
+
+/**
+ * @module ember-sortable
+ * @class Utilities
+ */
+
+/**
+ * Gets a numeric border-spacing value for a given element.
+ *
+ * @method getBorderSpacing
+ * @param {Element} element
+ * @return {Object}
+ * @private
+ */
+export function getBorderSpacing(el) {
+  el = $(el);
+
+  let css = el.css('border-spacing'); // '0px 0px'
+  let [horizontal, vertical] = css.split(' ');
+
+  return {
+    horizontal: parseFloat(horizontal),
+    vertical: parseFloat(vertical)
+  };
+}
+
+/**
+ * Gets the x offset for a given event.
+ * Works for touch and mouse events.
+ *
+ * @method getX
+ * @param {Event} event
+ * @return {Number}
+ * @private
+ */
+export function getX(event) {
+  let originalEvent = event.originalEvent;
+  let touches = originalEvent && originalEvent.changedTouches;
+  let touch = touches && touches[0];
+
+  if (touch) {
+    return touch.screenX;
+  } else {
+    return event.pageX;
+  }
+}
+
+/**
+ * Gets the y offset for a given event.
+ * Works for touch and mouse events.
+ *
+ * @method getY
+ * @param {Event} event
+ * @return {Number}
+ * @private
+ */
+export function getY(event) {
+  let originalEvent = event.originalEvent;
+  let touches = originalEvent && originalEvent.changedTouches;
+  let touch = touches && touches[0];
+
+  if (touch) {
+    return touch.screenY;
+  } else {
+    return event.pageY;
+  }
+}

--- a/addon/templates/components/sortable-item.hbs
+++ b/addon/templates/components/sortable-item.hbs
@@ -1,1 +1,1 @@
-{{yield this}}
+{{yield _actionsHash}}

--- a/addon/utils/set-indexies.js
+++ b/addon/utils/set-indexies.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+function setIndexies(array) {
+  array.forEach( (item, index)=> Ember.set(item, 'index', index) );
+}
+
+export default setIndexies;
+

--- a/app/components/sortable-group.js
+++ b/app/components/sortable-group.js
@@ -1,3 +1,1 @@
-import sortableGroup from 'ember-sortable/components/sortable-group';
-
-export default sortableGroup;
+export {default} from 'ember-sortable/components/sortable-group';

--- a/app/components/sortable-item.js
+++ b/app/components/sortable-item.js
@@ -1,3 +1,1 @@
-import sortableItem from 'ember-sortable/components/sortable-item';
-
-export default sortableItem;
+export {default} from 'ember-sortable/components/sortable-item';

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cli-yuidoc": "0.8.7",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.10"
+    "loader.js": "^4.0.10",
+    "yuidoc-ember-theme": "^1.2.1"
   },
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
-    "ember-invoke-action": "^1.4.0",
-    "ember-new-computed": "^1.0.2"
+    "ember-invoke-action": "^1.4.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/test-support/helpers/ember-sortable/test-helpers.js
+++ b/test-support/helpers/ember-sortable/test-helpers.js
@@ -1,2 +1,56 @@
+/**
+ * @module ember-sortable
+ * @class Test Helpers
+ */
+
+ /**
+  * Drags elements by an offset specified in pixels.
+  * Example:
+  *
+  * ```js
+  * drag(
+  *   'mouse',
+  *   '.some-list li[data-item=uno]',
+  *   function() {
+  *     return { dy: 50, dx: 20 };
+  *   }
+  * );
+  * ```
+  *
+  * @method drag
+  * @public
+  * @param {Ember.Application} app
+  * @param {'mouse'|'touch'} mode event mode
+  * @param {String} itemSelector selector for the element to drag
+  * @param {Function} offsetFn function returning the offset by which to drag
+  * @param {Object} callbacks callbacks that are fired at the different stages of the interaction
+  *
+  * @return {Promise}
+  */
+
 import 'ember-sortable/helpers/drag';
+
+/**
+ * Reorders elements to the specified state.
+ *
+ * Example:
+
+```js
+reorder(
+  'mouse',
+  '.some-list li',
+  '[data-id="66278893"]',
+  '[data-id="66278894"]',
+  '[data-id="66278892"]'
+);
+```
+ * @method reorder
+ * @public
+ * @param {Ember.Application} app
+ * @param {'mouse'|'touch'} mode event mode
+ * @param {String} itemSelector selector for all items
+ * @param {String} [...resultSelectors] selectors for the resultant order
+ * @return {Promise}
+ */
+
 import 'ember-sortable/helpers/reorder';

--- a/tests/acceptance/smoke-test.js
+++ b/tests/acceptance/smoke-test.js
@@ -199,6 +199,42 @@ test('reordering with touch events', function(assert) {
   });
 });
 
+test('reordering with buttons', function(assert) {
+  visit('/');
+
+  andThen(() => {
+    assert.equal(buttonsContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
+  });
+
+  click('.buttons-demo button.down:first');
+
+  andThen(() => {
+    assert.equal(buttonsContents(), 'Dos Uno Tres Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Dos Uno Tres Cuatro Cinco');
+  });
+
+  click('.buttons-demo button.up:first');
+
+  andThen(() => {
+    assert.equal(buttonsContents(), 'Dos Uno Tres Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Dos Uno Tres Cuatro Cinco');
+  });
+
+  click('.buttons-demo button.up:last');
+
+  andThen(() => {
+    assert.equal(buttonsContents(), 'Dos Uno Tres Cinco Cuatro');
+    assert.equal(horizontalContents(), 'Dos Uno Tres Cinco Cuatro');
+  });
+
+
+});
+
+function buttonsContents() {
+  return contents('.buttons-demo ol');
+}
+
 function verticalContents() {
   return contents('.vertical-demo ol');
 }
@@ -218,7 +254,7 @@ function scrollableContents() {
 function contents(selector) {
   return find(selector)
     .text()
-    .replace(/⇕/g, '')
+    .replace(/[⇕↑↓]/g, '')
     .replace(/\s+/g, ' ')
     .replace(/^\s+/, '')
     .replace(/\s+$/, '');

--- a/tests/acceptance/smoke-test.js
+++ b/tests/acceptance/smoke-test.js
@@ -101,6 +101,23 @@ test('reordering with mouse events', function(assert) {
     assert.equal(tableContents(), 'Dos Tres Uno Cuatro Cinco');
     assert.equal(scrollableContents(), 'Dos Tres Uno Cuatro Cinco');
   });
+
+  reorder(
+    'mouse',
+    '.vertical-distance-demo li',
+    ':contains("Tres")',
+    ':contains("Dos")',
+    ':contains("Uno")',
+    ':contains("Cuatro")',
+    ':contains("Cinco")'
+  );
+
+  andThen(() => {
+    assert.equal(verticalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(tableContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(scrollableContents(), 'Tres Dos Uno Cuatro Cinco');
+  });
 });
 
 test('reordering with touch events', function(assert) {
@@ -162,6 +179,23 @@ test('reordering with touch events', function(assert) {
     assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
+  });
+
+  reorder(
+    'touch',
+    '.vertical-distance-demo li',
+    ':contains("Tres")',
+    ':contains("Dos")',
+    ':contains("Uno")',
+    ':contains("Cuatro")',
+    ':contains("Cinco")'
+  );
+
+  andThen(() => {
+    assert.equal(verticalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(tableContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(scrollableContents(), 'Tres Dos Uno Cuatro Cinco');
   });
 });
 

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -43,23 +43,27 @@
 }
 
 
-.vertical-demo .sortable-item {
+.vertical-demo .sortable-item,
+.buttons-demo .sortable-item {
   display: block;
   position: relative;
   background: pink;
   margin: 4px 0;
 }
 
-.vertical-demo .sortable-item.is-dragging {
+.vertical-demo .sortable-item.is-dragging,
+.buttons-demo .sortable-item.is-dragging {
   background: red;
 }
 
-.vertical-demo .sortable-item.is-dropping {
+.vertical-demo .sortable-item.is-dropping,
+.buttons-demo .sortable-item.is-dropping {
   background: #f66;
   z-index: 10;
 }
 
-.vertical-demo .sortable-item .handle {
+.vertical-demo .sortable-item .handle,
+.buttons-demo .sortable-item .handle {
   display: block;
   position: absolute;
   top: 0; right: 0; bottom: 0;
@@ -159,6 +163,23 @@
   top: 0; right: 0; bottom: 0;
   background: rgba(127, 0, 0, .5);
   color: pink;
+}
+
+.move-button {
+  font-size: inherit;
+  height:100%;
+}
+
+.buttons-demo.with-buttons .sortable-item {
+  display: flex;
+}
+
+.buttons-demo.with-buttons .item {
+  flex-grow:1;
+}
+
+.buttons-demo.with-buttons .handle {
+  position:static;
 }
 
 #ember-testing {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -67,7 +67,7 @@
   color: pink;
 }
 
-.vertical-spacing-demo .sortable-item {
+.vertical-spacing-demo .sortable-item, .vertical-distance-demo .sortable-item {
   display: block;
   position: relative;
   background: #58D3F7;
@@ -77,7 +77,7 @@
   text-align: center;
 }
 
-.vertical-spacing-demo .sortable-item.is-dragging {
+.vertical-spacing-demo .sortable-item.is-dragging, .vertical-distance-demo .sortable-item.is-dragging {
   background: #A9E2F3;
 }
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -67,6 +67,20 @@
       {{/sortable-group}}
     </section>
 
+    <section class="vertical-distance-demo">
+      <h3>Vertical with distance set to 15</h3>
+
+      {{#sortable-group tagName="ol" onChange="update" as |group|}}
+        {{#each model.items as |item|}}
+          {{#sortable-item tagName="li" model=item group=group distance=15}}
+            {{item}}
+            <span class="handle" data-item="{{item}}">
+            </span>
+          {{/sortable-item}}
+        {{/each}}
+      {{/sortable-group}}
+    </section>
+
     <section class="scrollable-demo">
       <h3>Scrollable</h3>
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -29,7 +29,25 @@
           {{/sortable-item}}
         {{/each}}
       {{/sortable-group}}
+    </section>
 
+    <section class="buttons-demo with-buttons">
+      <h3>With buttons</h3>
+
+      {{#sortable-group tagName="ol" onChange="update" as |group|}}
+        {{#each model.items as |item|}}
+          {{#sortable-item tagName="li" model=item group=group handle=".handle" as |sortItem|}}
+            <span class="item">
+              {{item}}
+            </span>
+            <button class="move-button up" onclick={{sortItem.moveUp}}>&uarr;</button>
+            <button class="move-button down" onclick={{sortItem.moveDown}}>&darr;</button>
+            <span class="handle" data-item="{{item}}">
+              <span>&vArr;</span>
+            </span>
+          {{/sortable-item}}
+        {{/each}}
+      {{/sortable-group}}
     </section>
 
     <section class="table-demo">

--- a/tests/integration/components/sortable-group-test.js
+++ b/tests/integration/components/sortable-group-test.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+import $ from 'jquery';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+const { run } = Ember;
+
+moduleForComponent('sortable-group', 'Integration | Component | sortable group', {
+  integration: true
+});
+
+test('distance attribute prevents the drag before the specified value', function(assert) {
+  this.render(hbs`
+    {{#sortable-group as |group|}}
+      {{#sortable-item distance=15 model=1 group=group id="dummy-sortable-item"}}
+        {{item}}
+      {{/sortable-item}}
+    {{/sortable-group}}
+  `);
+
+  let item = $('#dummy-sortable-item');
+  let itemOffset = item.offset();
+
+  triggerEvent(item, 'mousedown', { pageX: itemOffset.left, pageY: itemOffset.top, which: 1 });
+  triggerEvent(item, 'mousemove', { pageX: itemOffset.left, pageY: itemOffset.top, which: 1 });
+  triggerEvent(item, 'mousemove', { pageX: itemOffset.left, pageY: itemOffset.top + 5, which: 1 });
+
+  assert.notOk(item.hasClass('is-dragging'), 'does not start dragging if the drag distance is less than the passed one');
+
+  triggerEvent(item, 'mousemove', { pageX: itemOffset.left, pageY: itemOffset.top + 20, which: 1 });
+
+  assert.ok(item.hasClass('is-dragging'), 'starts dragging if the drag distance is more than the passed one');
+});
+
+function triggerEvent(el, type, props) {
+  run(() => {
+    let event = $.Event(type, props);
+    $(el).trigger(event);
+  });
+}

--- a/tests/unit/components/sortable-group-test.js
+++ b/tests/unit/components/sortable-group-test.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 import Ember from 'ember';
-const { run } = Ember;
+const { run, A:a } = Ember;
 
 moduleForComponent('sortable-group', { unit: true });
 
@@ -15,16 +15,16 @@ test('items', function(assert) {
 });
 
 test('sortedItems', function(assert) {
-  let items = [{ y: 30 }, { y: 10 }, { y: 20 }];
+  let items = a([{ index: 2 }, { index: 0 }, { index: 1 }]);
   let component = this.subject({ items });
-  let expected = [{ y: 10 }, { y: 20 }, { y: 30 }];
+  let expected = [{ index: 0 }, { index: 1 }, { index: 2 }];
 
   assert.deepEqual(component.get('sortedItems'), expected,
-    'expected sortedItems to sort on y');
+    'expected sortedItems to sort on index');
 });
 
 test('[de]registerItem', function(assert) {
-  let item = 'foo';
+  let item = {};
   let component = this.subject();
 
   component.registerItem(item);
@@ -39,7 +39,7 @@ test('[de]registerItem', function(assert) {
 });
 
 test('update', function(assert) {
-  let items = [{
+  let items = a([{
     y: 10,
     height: 15,
     spacing: 0
@@ -52,7 +52,7 @@ test('update', function(assert) {
     height: 20,
     spacing: 0,
     isDragging: true
-  }];
+  }]);
   let component = this.subject({ items });
 
   this.render();
@@ -60,18 +60,23 @@ test('update', function(assert) {
   component.update();
 
   let expected = [{
-    y: 25,
     height: 15,
-    spacing: 0
-  }, {
-    y: 40,
-    height: 10,
-    spacing: 0
-  }, {
-    y: 5,
-    height: 20,
+    index: 1,
     spacing: 0,
-    isDragging: true
+    y: 10
+  },
+  {
+    height: 10,
+    index: 2,
+    spacing: 0,
+    y: 25
+  },
+  {
+    height: 20,
+    index: 0,
+    isDragging: true,
+    spacing: 0,
+    y: 5
   }];
 
 
@@ -80,24 +85,28 @@ test('update', function(assert) {
 });
 
 test('update', function(assert) {
-  let items = [{
+  let items = a([{
     y: 15,
+    index: 0,
     height: 15,
     spacing: 10
   }, {
     y: 20,
+    index: 1,
     height: 10,
     spacing: 10
   }, {
     y: 35,
+    index: 2,
     height: 25,
     spacing: 10,
     isDragging: true
   }, {
     y: 45,
+    index: 3,
     height: 20,
     spacing: 10
-  }];
+  }]);
 
   let component = this.subject({ items });
 
@@ -107,19 +116,23 @@ test('update', function(assert) {
 
   let expected = [{
     y: 5,
+    index: 0,
     height: 15,
     spacing: 10
   }, {
     y: 20,
+    index: 1,
     height: 10,
     spacing: 10
   }, {
     y: 35,
+    index: 2,
     height: 25,
     spacing: 10,
     isDragging: true
   }, {
     y: 55,
+    index: 3,
     height: 20,
     spacing: 10,
   }];
@@ -129,24 +142,28 @@ test('update', function(assert) {
 });
 
 test('update', function(assert) {
-  let items = [{
+  let items = a([{
     y: 15,
+    index: 0,
     height: 15,
     spacing: 8
   }, {
     y: 20,
+    index: 1,
     height: 10,
     spacing: 9
   }, {
     y: 35,
+    index: 2,
     height: 25,
     spacing: 10,
     isDragging: true
   }, {
     y: 45,
+    index: 3,
     height: 20,
     spacing: 11
-  }];
+  }]);
 
   let component = this.subject({ items });
 
@@ -156,19 +173,23 @@ test('update', function(assert) {
 
   let expected = [{
     y: 7,
+    index: 0,
     height: 15,
     spacing: 8
   }, {
     y: 22,
+    index: 1,
     height: 10,
     spacing: 9
   }, {
     y: 35,
+    index: 2,
     height: 25,
     spacing: 10,
     isDragging: true
   }, {
     y: 57,
+    index: 3,
     height: 20,
     spacing: 11,
   }];
@@ -178,24 +199,28 @@ test('update', function(assert) {
 });
 
 test('update', function(assert) {
-  let items = [{
+  let items = a([{
     x: 15,
+    index: 0,
     width: 15,
     spacing: 10
   }, {
     x: 20,
+    index: 1,
     width: 10,
     spacing: 10
   }, {
     x: 35,
+    index: 2,
     width: 25,
     spacing: 10,
     isDragging: true
   }, {
     x: 45,
+    index: 3,
     width: 20,
     spacing: 10
-  }];
+  }]);
 
   let component = this.subject({
     items,
@@ -208,19 +233,23 @@ test('update', function(assert) {
 
   let expected = [{
     x: 5,
+    index: 0,
     width: 15,
     spacing: 10
   }, {
     x: 20,
+    index: 1,
     width: 10,
     spacing: 10
   }, {
     x: 35,
+    index: 2,
     width: 25,
     spacing: 10,
     isDragging: true
   }, {
     x: 55,
+    index: 3,
     width: 20,
     spacing: 10,
   }];
@@ -230,16 +259,16 @@ test('update', function(assert) {
 });
 
 test('commit without specified group model', function(assert) {
-  let items = [{
-    y: 20,
+  let items = a([{
+    index: 1,
     model: 'bar'
   }, {
-    y: 30,
+    index: 2,
     model: 'baz'
   }, {
-    y: 10,
+    index: 0,
     model: 'foo'
-  }];
+  }]);
 
   let targetObject = Ember.Object.create({
     reorder(newOrder) {
@@ -261,16 +290,16 @@ test('commit without specified group model', function(assert) {
 });
 
 test('commit with specified group model', function(assert) {
-  let items = [{
-    y: 20,
+  let items = a([{
+    index: 1,
     model: 'bar'
   }, {
-    y: 30,
+    index: 2,
     model: 'baz'
   }, {
-    y: 10,
+    index: 0,
     model: 'foo'
-  }];
+  }]);
 
   let model = {
     items: items
@@ -297,7 +326,7 @@ test('commit with specified group model', function(assert) {
 });
 
 test('commit with missmatched group model', function(assert) {
-  let items = [{
+  let items = a([{
     y: 20,
     model: 'bar'
   }, {
@@ -306,7 +335,7 @@ test('commit with missmatched group model', function(assert) {
   }, {
     y: 10,
     model: 'foo'
-  }];
+  }]);
   let model = null;
   let targetObject = Ember.Object.create({
     reorder(model, newOrder) {
@@ -333,7 +362,7 @@ test('commit with missmatched group model', function(assert) {
 test('draggedModel', function(assert) {
   assert.expect(1);
 
-  let items = [{
+  let items = a([{
     y: 1,
     model: 'One',
   }, {
@@ -343,7 +372,7 @@ test('draggedModel', function(assert) {
   }, {
     y: 3,
     model: 'Three'
-  }];
+  }]);
 
   let targetObject = {
     action(models, draggedModel) {

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,0 +1,24 @@
+{
+  "name": "Ember Sortable",
+  "description": "",
+  "url": "https://github.com/jgwhite/ember-sortable",
+  "options": {
+    "enabledEnvironments": ["production"],
+    "paths": ["addon", "test-support"],
+    "external": {
+      "data": [{
+        "base": "http://emberjs.com/api/",
+        "json": "http://builds.emberjs.com/tags/v2.9.1/ember-docs.json"
+      }]
+    },
+    "themedir": "node_modules/yuidoc-ember-theme",
+    "helpers": ["node_modules/yuidoc-ember-theme/helpers/helpers.js"],
+    "exclude": "vendor",
+    "outdir": "docs",
+    "linkNatives": true,
+    "quiet": true,
+    "parseOnly": false,
+    "lint": false,
+    "nocode": false
+  }
+}


### PR DESCRIPTION
Adding actions yielded from `{{sortable-item}}` to move up/down using buttons.
![sortable buttons](https://user-images.githubusercontent.com/697625/30490731-87acfd48-9a43-11e7-95a8-b794c5bd2376.gif)


Closes #153.

 - [x] tests
 - [x] implementation
 - [x] demo
 - [x] docs

---