### PR TITLE
Closest polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Version 1.0 depends upon the availability of 2D CSS transforms.
 Check [the matrix on caniuse.com](http://caniuse.com/#feat=transforms2d)
 to see if your target browsers are compatible.
 
-As of version 1.12.2 `ember-sortable` depends on `Element.closest`, which is [unsupported in all versions of Internet Explorer](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Browser_compatibility). A polyfill is available - both [on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill), and [as a package](https://github.com/jonathantneal/closest).
+As of version 1.12.2 `ember-sortable` depends on `Element.closest`, which is [unsupported in all versions of Internet Explorer](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Browser_compatibility). A polyfill is available - both [on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill), and [as a package](https://github.com/jonathantneal/closest). This will be polyfilled in versions > 1.12.11.
 
 ## Installation
 

--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -10,6 +10,7 @@ import layout from '../templates/components/sortable-item';
 import { getBorderSpacing } from '../utils/css-calculation';
 import { DRAG_ACTIONS, ELEMENT_CLICK_ACTION, END_ACTIONS } from '../utils/constant';
 import { getX, getY } from '../utils/coordinate';
+import closestPolyfill from '../utils/polyfill/closest';
 
 export default Component.extend({
   layout,
@@ -243,6 +244,12 @@ export default Component.extend({
     minimal overriding.
   */
   _direction: computed.readOnly('group.direction'),
+
+  init() {
+    this._super();
+
+    closestPolyfill(window);
+  },
 
   /**
     @method didInsertElement

--- a/addon/utils/polyfill/closest.js
+++ b/addon/utils/polyfill/closest.js
@@ -1,0 +1,43 @@
+// Polyfill for 'closest' and `matches` in IE11.
+// https://github.com/jonathantneal/closest
+export default function polyfill(window) {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    (function(ElementProto) {
+      if (typeof ElementProto.matches !== 'function') {
+        ElementProto.matches =
+          ElementProto.msMatchesSelector ||
+          ElementProto.mozMatchesSelector ||
+          ElementProto.webkitMatchesSelector ||
+          function matches(selector) {
+            var element = this;
+            var elements = (
+              element.document || element.ownerDocument
+            ).querySelectorAll(selector);
+            var index = 0;
+
+            while (elements[index] && elements[index] !== element) {
+              ++index;
+            }
+
+            return Boolean(elements[index]);
+          };
+      }
+
+      if (typeof ElementProto.closest !== 'function') {
+        ElementProto.closest = function closest(selector) {
+          var element = this;
+
+          while (element && element.nodeType === 1) {
+            if (element.matches(selector)) {
+              return element;
+            }
+
+            element = element.parentNode;
+          }
+
+          return null;
+        };
+      }
+    })(window.Element.prototype);
+  }
+}


### PR DESCRIPTION
    1. Adding element-closest package to support IE9+ support for Element.closest
    2. Adding note to README regarding which version will polyfill it.

Solves #241 
More than glad to have a better way to polyfill this. Since I only see it used in `sortable-item`, I only polyfilled there...