### PR TITLE
Deprecating sendAction

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -13,6 +13,17 @@ export default Component.extend({
   attributeBindings: ['data-test-selector'],
 
   /**
+    Called when order of items has been changed
+    @property onChange
+    @type Action
+    @param object group model (omitted if not set)
+    @param array item models in their new order
+    @param object item model just dragged
+    @default null
+  */
+  onChange: function() {},
+
+  /**
     @property direction
     @type string
     @default y
@@ -153,9 +164,9 @@ export default Component.extend({
     });
 
     if (groupModel !== NO_MODEL) {
-      this.sendAction('onChange', groupModel, itemModels, draggedModel);
+      this.onChange(groupModel, itemModels, draggedModel);
     } else {
-      this.sendAction('onChange', itemModels, draggedModel);
+      this.onChange(itemModels, draggedModel);
     }
   }
 });

--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -70,17 +70,19 @@ export default Component.extend({
     Action that fires when the item starts being dragged.
     @property onDragStart
     @type Action
+    @param object item model
     @default null
   */
-  onDragStart: null,
+  onDragStart: function() {},
 
   /**
     Action that fires when the item stops being dragged.
     @property onDragStop
     @type Action
+    @param object item model
     @default null
   */
-  onDragStop: null,
+  onDragStop: function() {},
 
   /**
     True if the item is currently dropping.
@@ -416,7 +418,7 @@ export default Component.extend({
 
     this._tellGroup('prepare');
     this.set('isDragging', true);
-    this.sendAction('onDragStart', this.get('model'));
+    this.onDragStart(this.get('model'));
     this._scrollOnEdges(drag);
   },
 
@@ -696,7 +698,7 @@ export default Component.extend({
     @private
   */
   _complete() {
-    this.sendAction('onDragStop', this.get('model'));
+    this.onDragStop(this.get('model'));
     this.set('isDropping', false);
     this.set('wasDropped', true);
     this._tellGroup('commit');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ember-source": "~3.7.0",
     "ember-source-channel-url": "^1.1.0",
     "ember-test-selectors": "^2.1.0",
+    "ember-test-waiters": "^1.1.1",
     "ember-try": "^1.0.0",
     "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-node": "^7.0.1",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+import { set } from '@ember/object';
+import { A as a } from '@ember/array';
+
+
+export default Controller.extend({
+  actions: {
+    update(newOrder, draggedModel) {
+      set(this, 'model.items', a(newOrder));
+      set(this, 'model.dragged', draggedModel);
+    }
+  }
+})

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -7,11 +7,4 @@ export default Route.extend({
       items: a(['Uno', 'Dos', 'Tres', 'Cuatro', 'Cinco'])
     };
   },
-
-  actions: {
-    update(newOrder, draggedModel) {
-      this.set('currentModel.items', a(newOrder));
-      this.set('currentModel.dragged', draggedModel);
-    }
-  }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -7,7 +7,7 @@
     <section class="vertical-demo">
       <h3>Vertical</h3>
 
-      {{#sortable-group tagName="ol" onChange="update" as |group|}}
+      {{#sortable-group tagName="ol" onChange=(action "update") as |group|}}
         {{#each model.items as |item|}}
           {{#sortable-item data-test-vertical-demo-item tagName="li" model=item group=group handle=".handle"}}
             {{item}}
@@ -22,7 +22,7 @@
     <section class="horizontal-demo">
       <h3>Horizontal</h3>
 
-      {{#sortable-group tagName="ol" direction="x" onChange="update" as |group|}}
+      {{#sortable-group tagName="ol" direction="x" onChange=(action "update") as |group|}}
         {{#each model.items as |item|}}
           {{#sortable-item data-test-horizontal-demo-handle tagName="li" model=item group=group}}
             {{item-presenter item=item}}
@@ -43,7 +43,7 @@
             <th>Item</th>
           </tr>
         </thead>
-        {{#sortable-group tagName="tbody" onChange="update" as |group|}}
+        {{#sortable-group tagName="tbody" onChange=(action "update") as |group|}}
           {{#each model.items as |item|}}
             {{#sortable-item data-test-table-demo-item tagName="tr" model=item group=group handle=".handle"}}
               <td><span data-test-table-demo-handle class="handle" data-item={{item}}>&vArr;</span></td>
@@ -57,7 +57,7 @@
     <section class="vertical-spacing-demo">
       <h3>Vertical with 15px spacing</h3>
 
-      {{#sortable-group tagName="ol" onChange="update" as |group|}}
+      {{#sortable-group tagName="ol" onChange=(action "update") as |group|}}
         {{#each model.items as |item|}}
           {{#sortable-item tagName="li" model=item group=group spacing=15}}
             {{item}}
@@ -71,7 +71,7 @@
     <section class="vertical-distance-demo">
       <h3>Vertical with distance set to 15</h3>
 
-      {{#sortable-group tagName="ol" onChange="update" as |group|}}
+      {{#sortable-group tagName="ol" onChange=(action "update") as |group|}}
         {{#each model.items as |item|}}
           {{#sortable-item data-test-vertical-distance-demo-handle tagName="li" model=item group=group distance=15}}
             {{item}}
@@ -86,7 +86,7 @@
       <h3>Scrollable</h3>
 
       <div class="sortable-container">
-        {{#sortable-group tagName="ol" onChange="update" as |group|}}
+        {{#sortable-group tagName="ol" onChange=(action "update") as |group|}}
           {{#each model.items as |item|}}
             {{#sortable-item data-test-scrollable-demo-handle tagName="li" model=item group=group handle=".handle"}}
               {{item}}

--- a/tests/unit/components/sortable-group-test.js
+++ b/tests/unit/components/sortable-group-test.js
@@ -249,7 +249,7 @@ test('commit without specified group model', function(assert) {
   let component = this.subject({
     items,
     target,
-    onChange: 'reorder'
+    onChange: target.reorder.bind(target)
   });
 
   run(() => {
@@ -285,7 +285,7 @@ test('commit with specified group model', function(assert) {
     model,
     items,
     target,
-    onChange: 'reorder'
+    onChange: target.reorder.bind(target)
   });
 
   run(() => {
@@ -319,7 +319,7 @@ test('commit with missmatched group model', function(assert) {
     model,
     items,
     target,
-    onChange: 'reorder'
+    onChange: target.reorder.bind(target)
   });
 
   run(() => {
@@ -354,7 +354,7 @@ test('draggedModel', function(assert) {
   let component = this.subject({
     items,
     target,
-    onChange: 'action'
+    onChange: target.action.bind(target)
   });
 
   run(() => {

--- a/tests/unit/components/sortable-item-test.js
+++ b/tests/unit/components/sortable-item-test.js
@@ -216,7 +216,7 @@ test('dragStart fires an action if provided', function(assert) {
   run(() => {
     subject.set('model', MockModel);
     subject.set('target', target);
-    subject.set('onDragStart', 'action');
+    subject.set('onDragStart', target.action.bind(target));
     subject._startDrag(MockEvent);
   });
 });
@@ -235,7 +235,7 @@ test('dragStop fires an action if provided', function(assert) {
   run(() => {
     subject.set('model', MockModel);
     subject.set('target', target);
-    subject.set('onDragStop', 'action');
+    subject.set('onDragStop', target.action.bind(target));
     subject._complete();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3346,6 +3346,13 @@ ember-test-selectors@^2.1.0:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^3.1.2"
 
+ember-test-waiters@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-1.1.1.tgz#7df6e7a47e0fdca814aa351f7f7f9a006e15fdcd"
+  integrity sha512-ra71ZWTGBGLeDPa308aeAg9+/nYxv2fk4OEzmXdhvbSa5Dtbei94sr5pbLXx2IiK3Re2gDAvDzxg9PVhLy9fig==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+
 ember-try-config@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-try-config/-/ember-try-config-3.0.0.tgz#012d8c90cae9eb624e2b62040bf7e76a1aa58edc"


### PR DESCRIPTION
This will cause backward incompatbility if a consumer is passing in `actions` as `strings`, e.g
`onDragStart="onDragStart"` instead of `onDragStart=(action "onDragStart")`