### PR TITLE
Adding sortable-handle

### DIFF
--- a/addon/components/sortable-handle.js
+++ b/addon/components/sortable-handle.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  attributeBindings: ["dataSortableHandle:data-sortable-handle"],
+  dataSortableHandle: true,
+});

--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -39,12 +39,16 @@ export default Component.extend({
 
   /**
     Selector for the element to use as handle.
-    If unset, the entire element will be used as the handle.
+    1. By default, we will hook it the yielded sortable-handle.
+    2. If you don't use the sortable-handle, the entire element will be used as the handle.
+    3. In very rare situations, if you want to use a handle, but not the sortable-handle,
+       you can override this class with your own handle's selector. This behavior will be
+       synonymous with v1
     @property handle
     @type String
-    @default null
+    @default "[data-sortable-handle]"
   */
-  handle: null,
+  handle: "[data-sortable-handle]",
 
   /**
    * Tolerance, in pixels, for when sorting should start.
@@ -251,7 +255,6 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-
   },
   /**
     @method didInsertElement
@@ -264,10 +267,15 @@ export default Component.extend({
 
     // Instead of using `event.preventDefault()` in the 'primeDrag' event,
     // (doesn't work in Chrome 56), we set touch-action: none as a workaround.
-    let element = this.get('handle') ? this.element.querySelector(this.get('handle')) : this.element;
-    if (element) {
-      element.style['touch-action'] = 'none';
+    let handleElement = this.element.querySelector(this.get('handle'));
+
+    if (!handleElement) {
+      // Handle does not exist, so we set it null here.
+      this.set('handle', null);
+      handleElement = this.element;
     }
+
+    handleElement.style['touch-action'] = 'none';
   },
 
   /**

--- a/addon/templates/components/sortable-item.hbs
+++ b/addon/templates/components/sortable-item.hbs
@@ -1,1 +1,2 @@
-{{yield (hash handle=(component "sortable-handle" item=this))}}
+{{yield (hash handle=(component "sortable-handle"))}}
+

--- a/app/components/sortable-handle.js
+++ b/app/components/sortable-handle.js
@@ -1,0 +1,4 @@
+import sortableHandle from 'ember-sortable/components/sortable-handle';
+
+export default sortableHandle;
+

--- a/tests/acceptance/smoke-test.js
+++ b/tests/acceptance/smoke-test.js
@@ -65,7 +65,7 @@ module('Acceptance | smoke', function(hooks) {
       return item.offsetHeight + parseInt(itemStyle.marginTop);
     };
 
-    await drag('mouse', '[data-test-scrollable-demo-handle] > .handle', () => { return {dy: itemHeight() * 2 + 1, dx: undefined}});
+    await drag('mouse', '[data-test-scrollable-demo-handle] .handle', () => { return {dy: itemHeight() * 2 + 1, dx: undefined}});
 
     assert.equal(verticalContents(), 'Dos Tres Uno Cuatro Cinco');
     assert.equal(horizontalContents(), 'Dos Tres Uno Cuatro Cinco');

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -9,11 +9,13 @@
 
       {{#sortable-group tagName="ol" onChange=(action "update") as |group|}}
         {{#each model.items as |item|}}
-          {{#group.item data-test-vertical-demo-item tagName="li" model=item handle=".handle"}}
+          {{#group.item data-test-vertical-demo-item tagName="li" model=item handle=".handle" as |groupItem|}}
             {{item}}
-            <span data-test-vertical-demo-handle class="handle" data-item={{item}}>
-              <span>&vArr;</span>
-            </span>
+            {{#groupItem.handle}}
+              <span data-test-vertical-demo-handle class="handle" data-item={{item}}>
+                <span>&vArr;</span>
+              </span>
+            {{/groupItem.handle}}
           {{/group.item}}
         {{/each}}
       {{/sortable-group}}
@@ -45,9 +47,11 @@
         </thead>
         {{#sortable-group tagName="tbody" onChange=(action "update") as |group|}}
           {{#each model.items as |item|}}
-            {{#group.item data-test-table-demo-item tagName="tr" model=item handle=".handle"}}
-              <td><span data-test-table-demo-handle class="handle" data-item={{item}}>&vArr;</span></td>
-              <td>{{item}}</td>
+            {{#group.item data-test-table-demo-item tagName="tr" model=item handle=".handle" as |groupItem|}}
+              {{#groupItem.handle}}
+                <td><span data-test-table-demo-handle class="handle" data-item={{item}}>&vArr;</span></td>
+                <td>{{item}}</td>
+              {{/groupItem.handle}}
             {{/group.item}}
           {{/each}}
         {{/sortable-group}}
@@ -61,7 +65,7 @@
         {{#each model.items as |item|}}
           {{#group.item tagName="li" model=item spacing=15}}
             {{item}}
-            <span data-test-vertical-spacing-demo-handle class="handle" data-item={{item}}>
+            <span data-test-vertical-spacing-demo-handle data-item={{item}}>
             </span>
           {{/group.item}}
         {{/each}}
@@ -75,7 +79,7 @@
         {{#each model.items as |item|}}
           {{#group.item data-test-vertical-distance-demo-handle tagName="li" model=item distance=15}}
             {{item}}
-            <span class="handle" data-item={{item}}>
+            <span data-item={{item}}>
             </span>
           {{/group.item}}
         {{/each}}
@@ -88,11 +92,13 @@
       <div class="sortable-container">
         {{#sortable-group tagName="ol" onChange=(action "update") as |group|}}
           {{#each model.items as |item|}}
-            {{#group.item data-test-scrollable-demo-handle tagName="li" model=item handle=".handle"}}
+            {{#group.item data-test-scrollable-demo-handle tagName="li" model=item as |groupItem|}}
               {{item}}
-              <span class="handle" data-item={{item}}>
-                <span>&vArr;</span>
-              </span>
+              {{#groupItem.handle}}
+                <span class="handle" data-item={{item}}>
+                  <span>&vArr;</span>
+                </span>
+              {{/groupItem.handle}}
             {{/group.item}}
           {{/each}}
         {{/sortable-group}}


### PR DESCRIPTION
This will be the last PR to finish moving ember-sortable to become fully composable.
Also updated demo and all affected tests.
The benefit seems to be that the migration path is very straightforward!

Props to @H1D for initiating this.