### PR TITLE
Add beforedragend callback to `drag` helper

### DIFF
--- a/test-support/ember-sortable/helpers/drag.js
+++ b/test-support/ember-sortable/helpers/drag.js
@@ -103,6 +103,10 @@ export async function drag(
     clientY: targetY,
   });
 
+  if (callbacks.beforedragend) {
+    await callbacks.beforedragend();
+  }
+
   await triggerEvent(itemElement, end, {
     clientX: targetX,
     clientY: targetY,


### PR DESCRIPTION
👋 Thanks for maintaining this addon!

We recently ran into a case where we wanted to test application state while a drag was in-progress, before the final 'mouseup' was triggered. Would you accept this PR that adds a `beforedragend` optional callback?