### PR TITLE
Adding ember-sortable to the yield scope

### DIFF
--- a/addon/templates/components/sortable-group.hbs
+++ b/addon/templates/components/sortable-group.hbs
@@ -1,1 +1,1 @@
-{{yield (hash item=(component "sortable-item" group=this) model=model)}}
+{{yield (hash item=(component "ember-sortable@sortable-item" group=this) model=model)}}

--- a/addon/templates/components/sortable-item.hbs
+++ b/addon/templates/components/sortable-item.hbs
@@ -1,2 +1,2 @@
-{{yield (hash handle=(component "sortable-handle"))}}
+{{yield (hash handle=(component "ember-sortable@sortable-handle"))}}
 


### PR DESCRIPTION
External consumer fails in integration test b/c `sortable-item` couldn't be found.