### PR TITLE
Refactoring group into actions and pass actions instead

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -144,95 +144,6 @@ export default Component.extend({
   },
 
   /**
-    Register an item with this group.
-    @method registerItem
-    @param {SortableItem} [item]
-  */
-  registerItem(item) {
-    this.get('items').addObject(item);
-  },
-
-  /**
-    De-register an item with this group.
-    @method deregisterItem
-    @param {SortableItem} [item]
-  */
-  deregisterItem(item) {
-    this.get('items').removeObject(item);
-  },
-
-  /**
-    Prepare for sorting.
-    Main purpose is to stash the current itemPosition so
-    we don’t incur expensive re-layouts.
-    @method prepare
-  */
-  prepare() {
-    this._itemPosition = this.get('itemPosition');
-  },
-
-  /**
-    Update item positions (relatively to the first element position).
-    @method update
-  */
-  update() {
-    let sortedItems = this.get('sortedItems');
-    // Position of the first element
-    let position = this._itemPosition;
-
-    // Just in case we haven’t called prepare first.
-    if (position === undefined) {
-      position = this.get('itemPosition');
-    }
-
-    sortedItems.forEach(item => {
-      let dimension;
-      let direction = this.get('direction');
-
-      if (!get(item, 'isDragging')) {
-        set(item, direction, position);
-      }
-
-      // add additional spacing around active element
-      if (get(item, 'isBusy')) {
-        position += get(item, 'spacing') * 2;
-      }
-
-      if (direction === 'x') {
-        dimension = 'width';
-      }
-      if (direction === 'y') {
-        dimension = 'height';
-      }
-
-      position += get(item, dimension);
-    });
-  },
-
-  /**
-    @method commit
-  */
-  commit() {
-    const items = this.get('sortedItems');
-    const groupModel = this.get('groupModel');
-    const itemModels = items.mapBy('model');
-    const draggedItem = items.findBy('wasDropped', true);
-    let draggedModel;
-
-    if (draggedItem) {
-      set(draggedItem, 'wasDropped', false); // Reset
-      draggedModel = get(draggedItem, 'model');
-    }
-
-    this._updateItems();
-    if (groupModel !== NO_MODEL) {
-      this.onChange(groupModel, itemModels, draggedModel);
-    } else {
-      this.onChange(itemModels, draggedModel);
-    }
-  },
-
-  /**
    * Explanation
    * 1. `KeyboardReorderMode` is disabled: users can activate it via ENTER or SPACE.
    * 2. `KeyboardReorderMode` is enabled: users can reorder via UP or DOWN arrow keys. TODO: Expand to more keys, e.g LEFT, RIGHT
@@ -302,6 +213,7 @@ export default Component.extend({
     const { sortedItems, moves } = this.getProperties('sortedItems', 'moves');
     const sortedIndex = sortedItems.indexOf(item);
     const newSortedIndex = sortedIndex + delta;
+
     // If out of bounds, we don't do anything.
     if (newSortedIndex < 0 || newSortedIndex >= sortedItems.length) {
       return;
@@ -364,6 +276,116 @@ export default Component.extend({
     this._updateItemVisualIndicators(_selectedItem, false);
     this._updateHandleVisualIndicators(_selectedItem, false);
     this._resetItemSelection();
+  },
+
+  /**
+   * Enables keyboard navigation
+   */
+  _activateKeyDown(){
+    this.set('isKeyDownEnabled', true);
+  },
+
+  /**
+   * Disables keyboard navigation
+   * Currently used to handle keydown events bubbling up from
+   * elements that aren't meant to invoke keyboard navigation
+   * by ignoring them.
+   */
+  _deactivateKeyDown() {
+    this.set('isKeyDownEnabled', false);
+  },
+
+  /**
+    Register an item with this group.
+    @method registerItem
+    @param {SortableItem} [item]
+  */
+  _registerItem(item) {
+    this.get('items').addObject(item);
+  },
+
+  /**
+    De-register an item with this group.
+    @method deregisterItem
+    @param {SortableItem} [item]
+  */
+  _deregisterItem(item) {
+    this.get('items').removeObject(item);
+  },
+
+  _setSelectedItem(item) {
+    this.set('_selectedItem', item);
+  },
+
+  /**
+    Prepare for sorting.
+    Main purpose is to stash the current itemPosition so
+    we don’t incur expensive re-layouts.
+    @method _=repare
+  */
+  _prepare() {
+    this._itemPosition = this.get('itemPosition');
+  },
+
+  /**
+    Update item positions (relatively to the first element position).
+    @method update
+  */
+  _update() {
+    let sortedItems = this.get('sortedItems');
+    // Position of the first element
+    let position = this._itemPosition;
+
+    // Just in case we haven’t called prepare first.
+    if (position === undefined) {
+      position = this.get('itemPosition');
+    }
+
+    sortedItems.forEach(item => {
+      let dimension;
+      let direction = this.get('direction');
+
+      if (!get(item, 'isDragging')) {
+        set(item, direction, position);
+      }
+
+      // add additional spacing around active element
+      if (get(item, 'isBusy')) {
+        position += get(item, 'spacing') * 2;
+      }
+
+      if (direction === 'x') {
+        dimension = 'width';
+      }
+      if (direction === 'y') {
+        dimension = 'height';
+      }
+
+      position += get(item, dimension);
+    });
+  },
+
+  /**
+    @method _commit
+  */
+  _commit() {
+    const items = this.get('sortedItems');
+    const groupModel = this.get('groupModel');
+    const itemModels = items.mapBy('model');
+    const draggedItem = items.findBy('wasDropped', true);
+    let draggedModel;
+
+    if (draggedItem) {
+      set(draggedItem, 'wasDropped', false); // Reset
+      draggedModel = get(draggedItem, 'model');
+    }
+
+    this._updateItems();
+    if (groupModel !== NO_MODEL) {
+      this.onChange(groupModel, itemModels, draggedModel);
+    } else {
+      this.onChange(itemModels, draggedModel);
+    }
   },
 
   /**
@@ -637,23 +659,6 @@ export default Component.extend({
   },
 
   /**
-   * Disables keyboard navigation
-   * Currently used to handle keydown events bubbling up from
-   * elements that aren't meant to invoke keyboard navigation
-   * by ignoring them.
-   */
-  deactivateKeyDown() {
-    this.set('isKeyDownEnabled', false);
-  },
-
-  /**
-   * Enables keyboard navigation
-   */
-  activateKeyDown(){
-    this.set('isKeyDownEnabled', true);
-  },
-
-  /**
    * Defining getters and setters to support native getter and setters until we decide to drop support for ember versions below 3.10
    */
   _setGetterSetters() {
@@ -685,4 +690,38 @@ export default Component.extend({
       }
     })
   },
+
+  actions: {
+    activateKeyDown(){
+      this._activateKeyDown();
+    },
+
+    deactivateKeyDown() {
+      this._deactivateKeyDown();
+    },
+
+    registerItem(item) {
+      this._registerItem(item);
+    },
+
+    deregisterItem(item) {
+      this._registerItem(item);
+    },
+
+    setSelectedItem(item) {
+      this._setSelectedItem(item);
+    },
+
+    prepare() {
+      this._prepare();
+    },
+
+    update() {
+      this._update();
+    },
+
+    commit() {
+      this._commit();
+    },
+  }
 });

--- a/addon/templates/components/sortable-group.hbs
+++ b/addon/templates/components/sortable-group.hbs
@@ -1,1 +1,16 @@
-{{yield (hash item=(component "ember-sortable@sortable-item" group=this) model=model)}}
+{{yield (
+  hash
+    item=(component "ember-sortable@sortable-item"
+      direction=direction
+      registerItem=(action "registerItem")
+      deregisterItem=(action "deregisterItem")
+      setSelectedItem=(action "setSelectedItem")
+      update=(action "update")
+      prepare=(action "prepare")
+      commit=(action "commit")
+      activateKeyDown=(action "activateKeyDown")
+      deactivateKeyDown=(action "deactivateKeyDown")
+    )
+    model=model
+  )
+}}

--- a/tests/unit/components/sortable-group-test.js
+++ b/tests/unit/components/sortable-group-test.js
@@ -19,7 +19,7 @@ test('sortedItems', function(assert) {
   const component = this.subject();
   const expected = [{ y: 10 }, { y: 20 }, { y: 30 }];
 
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
   assert.deepEqual(component.get('sortedItems'), expected,
     'expected sortedItems to sort on y');
 });
@@ -28,12 +28,12 @@ test('[de]registerItem', function(assert) {
   const item = 'foo';
   const component = this.subject();
 
-  component.registerItem(item);
+  component._registerItem(item);
 
   assert.ok(component.get('items').includes(item),
     'expected registerItem to add item to items');
 
-  component.deregisterItem(item);
+  component._deregisterItem(item);
 
   assert.ok(!component.get('items').includes(item),
     'expected registerItem to remove item from items');
@@ -55,11 +55,11 @@ test('update', function(assert) {
     isDragging: true
   }];
   const component = this.subject();
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
 
   this.render();
 
-  component.update();
+  component._update();
 
   const expected = [{
     y: 25,
@@ -102,11 +102,11 @@ test('update', function(assert) {
   }];
 
   const component = this.subject();
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
 
   this.render();
 
-  component.update();
+  component._update();
 
   const expected = [{
     y: 5,
@@ -152,11 +152,11 @@ test('update', function(assert) {
   }];
 
   const component = this.subject();
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
 
   this.render();
 
-  component.update();
+  component._update();
 
   const expected = [{
     y: 7,
@@ -204,11 +204,11 @@ test('update', function(assert) {
   const component = this.subject({
     direction: 'x'
   });
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
 
   this.render();
 
-  component.update();
+  component._update();
 
   const expected = [{
     x: 5,
@@ -255,11 +255,11 @@ test('commit without specified group model', function(assert) {
     onChange: target.reorder.bind(target)
   });
 
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
 
 
   run(() => {
-    component.commit();
+    component._commit();
   });
 
   assert.deepEqual(target.newOrder, ['foo', 'bar', 'baz'],
@@ -291,10 +291,10 @@ test('draggedModel', function(assert) {
     target,
     onChange: target.action.bind(target)
   });
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
 
   run(() => {
-    component.commit();
+    component._commit();
   });
 });
 
@@ -332,10 +332,10 @@ test('commit with specified group model', function(assert) {
     target,
     onChange: target.reorder.bind(target)
   });
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
 
   run(() => {
-    component.commit();
+    component._commit();
   });
 
   assert.deepEqual(target.newModel.newOrder, ['foo', 'bar', 'baz'],
@@ -366,10 +366,10 @@ test('commit with missmatched group model', function(assert) {
     target,
     onChange: target.reorder.bind(target)
   });
-  items.forEach(item => component.registerItem(item));
+  items.forEach(item => component._registerItem(item));
 
   run(() => {
-    component.commit();
+    component._commit();
   });
 
   assert.equal(target.correctActionFired, true,

--- a/tests/unit/components/sortable-item-test.js
+++ b/tests/unit/components/sortable-item-test.js
@@ -6,6 +6,7 @@ const MockEvent = { };
 const MockModel = { name: 'Mock Model' };
 const MockGroup = EmberObject.extend({
   direction: 'y',
+
   registerItem(item) {
     this.item = item;
   },
@@ -28,9 +29,14 @@ moduleForComponent('sortable-item', {
 
   beforeEach() {
     run(() => {
-      group = MockGroup.create();
       subject = this.subject();
-      subject.set('group', group);
+      group = MockGroup.create();
+      subject.set('direction', group.direction);
+      subject.set('registerItem', group.registerItem.bind(group));
+      subject.set('deregisterItem', group.deregisterItem.bind(group));
+      subject.set('update', group.update.bind(group));
+      subject.set('prepare', group.prepare.bind(group));
+      subject.set('commit', group.commit.bind(group));
     });
   },
 
@@ -138,6 +144,7 @@ test('set x', function(assert) {
 
   run(() => {
     group.set('direction', 'x');
+    subject.set('direction', 'x');
     subject.set('x', 50);
   });
 
@@ -179,7 +186,6 @@ test('registers itself with group', function(assert) {
   assert.expect(1);
 
   this.render();
-
   assert.equal(group.item, subject,
     'expected to be registered with group');
 });


### PR DESCRIPTION
The method of passing down the `group` into the `item` is a bit flaky. Seems like due to the timing of the `runloop scheduler`, functions such as `registerItem` aren't properly registered on the `group` when it needs to be available for the caller.

Moving to a more `action`-based approach seems to potentially mitigate this problem and remove the dependency on the `runloop scheduler`. It also seems like the better Ember practice, supporting the Data Down Action Up paradigm.
Could potentially mitigate #306 