### PR TITLE
[BUGFIX] Fixes scrolling outside of an overflow container's boundaries resolves#346

### DIFF
--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -386,7 +386,9 @@ export default Component.extend({
       if (this._pageX == null && this._pageY == null) { return; }
       return {
         pageX: this._pageX,
-        pageY: this._pageY
+        pageY: this._pageY,
+        clientX: this._pageX,
+        clientY: this._pageY
       };
     };
 


### PR DESCRIPTION
the coordinates util relies on clientY and clientX being available on the event passed to it. When creating a fakeEvent in the scrollOnEdges method, only pageX/Y was being passed. This commit adds in the clientX/Y coordinates as well to allow the existing getX/Y util to function properly

*Note* I wasn't able to come up with a suitable acceptance test as Im unable to trigger an event programmatically that mimics the browser behaviour. Manual testing has worked. If you have any ideas on how I might test this, I'd be happy to amend

Thanks!