### PR TITLE
fixes handle when using modifiers

### DIFF
--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -266,10 +266,7 @@ export default class SortableItemModifier extends Modifier {
       return;
     }
 
-    let handle = this.handle;
-
-    // todo what does this do? why do you have to null handle
-    if (!this.handleElement && !startEvent.target.closest(handle)) {
+    if (this.handleElement && !startEvent.target.closest(this.handle)) {
       return;
     }
 

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -740,12 +740,11 @@ export default class SortableItemModifier extends Modifier {
     // Instead of using `event.preventDefault()` in the 'primeDrag' event,
     // (doesn't work in Chrome 56), we set touch-action: none as a workaround.
     this.handleElement = this.element.querySelector(this.handle);
-
-    if (!this.handleElement) {
-      this.handleElement = this.element;
+    if (this.handleElement) {
+      this.handleElement.style['touch-action'] = 'none';
+    } else {
+      this.element.style['touch-action'] = 'none';
     }
-
-    this.handleElement.style['touch-action'] = 'none';
   }
 
   didInstall() {

--- a/tests/acceptance/smoke-modifier-test.js
+++ b/tests/acceptance/smoke-modifier-test.js
@@ -11,12 +11,25 @@ module('Acceptance | smoke modifier', function(hooks) {
   test('reordering with mouse events', async function(assert) {
     await visit('/modifier');
 
+    // when a handle is present, the element itself shall not be draggable
     assert.equal(verticalContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
 
-    let order = findAll('[data-test-vertical-demo-handle]').reverse();
+    let order = findAll('[data-test-vertical-demo-item]').reverse();
+    await reorder(
+      'mouse',
+      '[data-test-vertical-demo-item]',
+      ...order
+    );
+
+    assert.equal(verticalContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
+
+    order = findAll('[data-test-vertical-demo-handle]').reverse();
     await reorder(
       'mouse',
       '[data-test-vertical-demo-handle]',


### PR DESCRIPTION
I noticed that the handle does not work correctly within the modifiers version: Even when it is present, the whole sortable element is draggable. We should probably still add some tests that try to sort by trying to move a sortable element where a handler is present.