### PR TITLE
modifier: handle renders as draggable when dragging is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ember install ember-sortable
 
 ## Usage
 
-### component 
+### component
 ```hbs
 {{! app/templates/my-route.hbs }}
 
@@ -47,7 +47,7 @@ $ ember install ember-sortable
 {{/sortable-group}}
 ```
 
-### modifier 
+### modifier
 ```hbs
 {{! app/templates/my-route.hbs }}
 
@@ -277,6 +277,7 @@ This flag is intended as an utility to make your life easier with 3 main benefit
 1. You can now specify which `sortable-item` are not intended to be draggable/sortable.
 2. You do not have to duplicate the `sortable-item` UI just for the purpose of disabling the `sorting` behavior.
 3. Allows you to access the entire list of `models` for your `onChange` action, which can now be a mix of sortable and non-sortable items.
+When dragging is disabled the attribute `data-sortable-disabled=true` is added to the sortable item, so it is possible to style the handle when the element actually is draggable like `.sortable-item:not([data-sortable-disabled=true])`.
 
 ### Data down, actions up
 
@@ -296,8 +297,8 @@ component
   an ordered list, `ol`, by default.
 - `sortable-item`
   a list item, `li`, by default.
-  
-The modifier version can be attached to to any element that makes sense, 
+
+The modifier version can be attached to to any element that makes sense,
 
 ##### Keyboard Navigation
 There are 4 modes during keyboard navigation:

--- a/addon/modifiers/sortable-handle.js
+++ b/addon/modifiers/sortable-handle.js
@@ -17,10 +17,8 @@ import Modifier from 'ember-modifier';
 export default class SortableHandleModifier extends Modifier {
 
   didInstall() {
-    // take the model and look up the registered element, the tell that element you are the handle
-    this.element.dataset.sortableHandle=true;
+    this.element.dataset.sortableHandle = true;
     this.element.tabIndex = "0";
-    this.element.setAttribute("role", "button");
   }
 
 }

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -726,34 +726,64 @@ export default class SortableItemModifier extends Modifier {
   }
 
   addEventListener() {
-    this.element.addEventListener("keydown", this.keyDown);
-    this.element.addEventListener("mousedown", this.mouseDown);
-    this.element.addEventListener("touchstart", this.touchStart);
+    if (!this.listenersActive) {
+      this.handleElement.addEventListener("keydown", this.keyDown);
+      this.handleElement.addEventListener("mousedown", this.mouseDown);
+      this.handleElement.addEventListener("touchstart", this.touchStart);
+    }
+    this.listenersActive = true;
   }
 
   removeEventListener() {
-    this.element.removeEventListener("keydown", this.keyDown);
-    this.element.removeEventListener("mousedown", this.mouseDown);
-    this.element.removeEventListener("touchstart", this.touchStart);
+    if (this.listenersActive) {
+      this.handleElement.removeEventListener("keydown", this.keyDown);
+      this.handleElement.removeEventListener("mousedown", this.mouseDown);
+      this.handleElement.removeEventListener("touchstart", this.touchStart);
+      this.listenersActive = false;
+    }
   }
 
   didReceiveArguments() {
     this.element.classList.add(this.className);
 
-    // Instead of using `event.preventDefault()` in the 'primeDrag' event,
-    // (doesn't work in Chrome 56), we set touch-action: none as a workaround.
-    this.handleElement = this.element.querySelector(this.handle);
+    this.initializeHandleElement();
 
-    if (!this.handleElement) {
-      this.handleElement = this.element;
+    if (this.isDraggingDisabled) {
+      this.removeEventListener();
+      this.element.dataset.sortableDisabled = true;
+    } else {
+      this.addEventListener();
+      this.element.dataset.sortableItem = true;
+      this.element.sortableItem = this;
+      delete this.element.dataset.sortableDisabled;
+    }
+  }
+
+  initializeHandleElement() {
+    const handle = this.element.querySelector(this.handle);
+
+    // if already initialized and handle is the same
+    if (this.handleElement != null && (handle == this.handleElement) || this.element == this.handleElement) {
+      return;
     }
 
+    if (this.handleElement != null) {
+      this.removeEventListener();
+    }
+
+    if (!handle) {
+      this.handleElement = this.element;
+    } else {
+      this.handleElement = handle;
+    }
+
+    // Instead of using `event.preventDefault()` in the 'primeDrag' event,
+    // (doesn't work in Chrome 56), we set touch-action: none as a workaround.
     this.handleElement.style['touch-action'] = 'none';
   }
 
   didInstall() {
-    this.addEventListener();
-    this.element.dataset.sortableItem=true;
+    this.element.dataset.sortableItem = true;
     this.element.sortableItem = this;
   }
 

--- a/tests/acceptance/smoke-modifier-test.js
+++ b/tests/acceptance/smoke-modifier-test.js
@@ -11,12 +11,25 @@ module('Acceptance | smoke modifier', function(hooks) {
   test('reordering with mouse events', async function(assert) {
     await visit('/modifier');
 
+    // when a handle is present, the element itself shall not be draggable
     assert.equal(verticalContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
 
-    let order = findAll('[data-test-vertical-demo-handle]').reverse();
+    let order = findAll('[data-test-vertical-demo-item]').reverse();
+    await reorder(
+      'mouse',
+      '[data-test-vertical-demo-item]',
+      ...order
+    );
+
+    assert.equal(verticalContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
+
+    order = findAll('[data-test-vertical-demo-handle]').reverse();
     await reorder(
       'mouse',
       '[data-test-vertical-demo-handle]',

--- a/tests/acceptance/smoke-modifier-test.js
+++ b/tests/acceptance/smoke-modifier-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, find, findAll, triggerKeyEvent, focus, blur } from '@ember/test-helpers';
+import { click, visit, find, findAll, triggerKeyEvent, focus, blur } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { drag, reorder }  from 'ember-sortable/test-support/helpers';
 import { ENTER_KEY_CODE, SPACE_KEY_CODE, ESCAPE_KEY_CODE, ARROW_KEY_CODES } from "ember-sortable/test-support/utils/keyboard";
@@ -8,19 +8,34 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 module('Acceptance | smoke modifier', function(hooks) {
   setupApplicationTest(hooks);
 
-  test('reordering with mouse events', async function(assert) {
+  test('disabled elements should not be sortable', async function(assert) {
     await visit('/modifier');
 
-    // when a handle is present, the element itself shall not be draggable
+    // disable sorting
+    await click('[data-test-vertical-demo-disabled]');
+
     assert.equal(verticalContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
 
-    let order = findAll('[data-test-vertical-demo-item]').reverse();
+    const handles = findAll('[data-test-vertical-demo-handle]')
+
+    assert.ok(getComputedStyle(handles[0]).cursor == "auto");
+    assert.ok(handles[0].getAttribute('role') == undefined);
+    assert.ok(getComputedStyle(handles[1]).cursor == "auto");
+    assert.ok(handles[1].getAttribute('role') == undefined);
+    assert.ok(getComputedStyle(handles[2]).cursor == "auto");
+    assert.ok(handles[2].getAttribute('role') == undefined);
+    assert.ok(getComputedStyle(handles[3]).cursor == "auto");
+    assert.ok(handles[3].getAttribute('role') == undefined);
+    assert.ok(getComputedStyle(handles[4]).cursor == "auto");
+    assert.ok(handles[4].getAttribute('role') == undefined);
+
+    let order = findAll('[data-test-vertical-demo-handle]').reverse();
     await reorder(
       'mouse',
-      '[data-test-vertical-demo-item]',
+      '[data-test-vertical-demo-handle]',
       ...order
     );
 
@@ -29,7 +44,31 @@ module('Acceptance | smoke modifier', function(hooks) {
     assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
 
-    order = findAll('[data-test-vertical-demo-handle]').reverse();
+    // enable sorting
+    await click('[data-test-vertical-demo-disabled]');
+
+    await reorder(
+      'mouse',
+      '[data-test-vertical-demo-handle]',
+      ...order
+    );
+
+    assert.equal(verticalContents(), 'Cinco Cuatro Tres Dos Uno');
+    assert.equal(horizontalContents(), 'Cinco Cuatro Tres Dos Uno');
+    assert.equal(tableContents(), 'Cinco Cuatro Tres Dos Uno');
+    assert.equal(scrollableContents(), 'Cinco Cuatro Tres Dos Uno');
+
+  });
+
+  test('reordering with mouse events', async function(assert) {
+    await visit('/modifier');
+
+    assert.equal(verticalContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
+    assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
+
+    let order = findAll('[data-test-vertical-demo-handle]').reverse();
     await reorder(
       'mouse',
       '[data-test-vertical-demo-handle]',

--- a/tests/dummy/app/controllers/modifier.js
+++ b/tests/dummy/app/controllers/modifier.js
@@ -19,6 +19,8 @@ export default class ModifierController extends Controller {
 
   itemVisualClass = 'sortable-item--active';
 
+  verticalDisabled = false;
+
   a11yAnnouncementConfig = {
     ACTIVATE: function({ a11yItemName, index, maxLength, direction }) {
       let message = `${a11yItemName} at position, ${index + 1} of ${maxLength}, is activated to be repositioned.`;

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -36,12 +36,15 @@
 
 .demo .sortable-item .handle {
   padding: 0 .5em;
-  cursor: move;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  user-select: none;
 }
 
+.demo .sortable-item:not([data-sortable-disabled=true]) .handle {
+  cursor: move;
+}
 
 .vertical-demo .sortable-item {
   display: block;

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -7,6 +7,9 @@
     <section class="vertical-demo">
       <h3>Vertical</h3>
 
+      <input data-test-vertical-demo-disabled type="checkbox" id="disable-vertical-demo-group" checked={{readonly this.verticalDisabled}} onchange={{action (mut this.verticalDisabled) value="target.checked"}}>
+      <label for="disable-vertical-demo-group">disabled</label>
+
       <ol data-test-vertical-demo-group
         {{sortable-group
           onChange=this.update
@@ -17,7 +20,7 @@
         }}
       >
         {{#each model.items as |item|}}
-          <li data-test-vertical-demo-item {{sortable-item model=item}}>
+          <li data-test-vertical-demo-item {{sortable-item model=item isDraggingDisabled=this.verticalDisabled}}>
             {{item}}
             <span class="handle" data-test-vertical-demo-handle {{sortable-handle}} data-item={{item}}>
               <span>&vArr;</span>


### PR DESCRIPTION
For the modifier version there currently wasn't a way for a draggable elements to know when dragging is disabled. This PR adds the attribute `data-sortable-disabled=true` to the sortable item.
Additionally event listeners are not added to disabled elements. For instance we have a list, that usually is fixed, but want to allow for editing by resource owners. Always attaching event listeners would be a waste of resources in this case.
Event listeners are now attached to the handle instead of the sortable item - just seemed to make sense, as the item itself would not be draggable, only the handle would be