### PR TITLE
Actually use `onDragStop` argument rather then re-using `onDragStart`.

### DIFF
--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -154,7 +154,7 @@ export default class SortableItemModifier extends Modifier {
    @default null
    */
   get onDragStop() {
-    return this.args.named.onDragStart || (item => item);
+    return this.args.named.onDragStop || (item => item);
   }
 
   /**


### PR DESCRIPTION
Noticed that the supplied `onDragStart` handler was getting called twice and this seems to explain why. Looks like a simple refactoring mistake which slipped through in the previous beta release. 