### PR TITLE
Fix/auto scroll with document container

### DIFF
--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -148,6 +148,9 @@ export default Component.extend({
   */
   _direction: computed.readOnly('direction'),
 
+
+  disableCheckScrollBounds: Ember.testing,
+
   init() {
     this._super(...arguments);
     this._setGetterSetters();
@@ -425,8 +428,7 @@ export default Component.extend({
         requestAnimationFrame(checkScrollBounds);
       }
     };
-
-    if (!Ember.testing) {
+    if (!this.disableCheckScrollBounds) {
       requestAnimationFrame(checkScrollBounds);
     }
   },

--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { Promise, defer } from 'rsvp';
 import Component from '@ember/component';
 import { computed, defineProperty } from '@ember/object';
@@ -11,6 +10,11 @@ import { getBorderSpacing } from '../utils/css-calculation';
 import { DRAG_ACTIONS, ELEMENT_CLICK_ACTION, END_ACTIONS } from '../utils/constant';
 import { getX, getY } from '../utils/coordinate';
 import { buildWaiter } from 'ember-test-waiters';
+import config from 'ember-get-config';
+const { environment } = config;
+const isTesting = environment === 'test';
+
+
 
 const sortableItemWaiter = buildWaiter("sortable-item-waiter");
 
@@ -149,7 +153,7 @@ export default Component.extend({
   _direction: computed.readOnly('direction'),
 
 
-  disableCheckScrollBounds: Ember.testing,
+  disableCheckScrollBounds: isTesting,
 
   init() {
     this._super(...arguments);

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import Modifier from 'ember-modifier';
 import { Promise, defer } from 'rsvp';
 import {action, set} from '@ember/object';
@@ -14,6 +13,9 @@ import {getBorderSpacing} from "../utils/css-calculation";
 import { buildWaiter } from 'ember-test-waiters';
 import {inject as service} from '@ember/service';
 import {assert} from '@ember/debug';
+import config from 'ember-get-config';
+const { environment } = config;
+const isTesting = environment === 'test';
 
 const sortableItemWaiter = buildWaiter("sortable-item-waiter");
 
@@ -221,7 +223,7 @@ export default class SortableItemModifier extends Modifier {
    @default false
    */
   get disableCheckScrollBounds() {
-    return this.args.named.disableCheckScrollBounds != undefined ? this.args.named.disableCheckScrollBounds : Ember.testing;
+    return this.args.named.disableCheckScrollBounds != undefined ? this.args.named.disableCheckScrollBounds : isTesting;
   }
 
   /**

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -215,6 +215,16 @@ export default class SortableItemModifier extends Modifier {
   isBusy;
 
   /**
+   Removes the ability for the current item to be dragged
+   @property isDraggingDisabled
+   @type  boolean
+   @default false
+   */
+  get disableCheckScrollBounds() {
+    return this.args.named.disableCheckScrollBounds != undefined ? this.args.named.disableCheckScrollBounds : Ember.testing;
+  }
+
+  /**
    @method mouseDown
    */
   @action
@@ -449,7 +459,7 @@ export default class SortableItemModifier extends Modifier {
       }
     };
 
-    if (!Ember.testing) {
+    if (!this.disableCheckScrollBounds) {
       requestAnimationFrame(checkScrollBounds);
     }
   }

--- a/addon/system/scroll-container.js
+++ b/addon/system/scroll-container.js
@@ -1,23 +1,26 @@
 export default class ScrollContainer {
   constructor(element) {
-    this.element = element;
     this.isWindow = element === document;
+    this.element = this.isWindow ? document.documentElement : element;
+
     if (this.isWindow) {
-      this.top = this.scrollTop();
-      this.left = this.scrollLeft();
+      this.top = 0;
+      this.left = 0;
       this.width = document.documentElement.clientWidth;
       this.height = document.documentElement.clientHeight;
-      this.scrollWidth =  document.documentElement.clientWidth;
-      this.scrollHeight = document.documentElement.clientHeight;
     } else {
+      // Absolute position in document
       let { top, left } = this.element.getBoundingClientRect();
       this.top = top;
       this.left = left;
+      // Viewport size of the container element
       this.width = parseFloat(getComputedStyle(this.element).width);
       this.height = parseFloat(getComputedStyle(this.element).height);
-      this.scrollWidth = element.scrollWidth;
-      this.scrollHeight = element.scrollHeight;
     }
+    // Total size of the container element (including scrollable part)
+    this.scrollWidth = this.element.scrollWidth;
+    this.scrollHeight = this.element.scrollHeight;
+    // Max scroll pos
     this.maxScrollTop = this.scrollHeight - this.height;
     this.maxScrollLeft = this.scrollWidth - this.width;
   }
@@ -34,9 +37,6 @@ export default class ScrollContainer {
     if (value) {
       value = Math.max(0, Math.min(this.maxScrollTop, value));
       this.element.scrollTop = value;
-      if (this.isWindow) {
-        this.top = value;
-      }
       return value;
     }
     return this.element.scrollTop;
@@ -46,9 +46,6 @@ export default class ScrollContainer {
     if (value) {
       value = Math.max(0, Math.min(this.maxScrollLeft, value));
       this.element.scrollLeft = value;
-      if (this.isWindow) {
-        this.left = value;
-      }
       return value;
     }
     return this.element.scrollLeft;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-cli-uglify": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
+    "ember-get-config": "^0.2.4",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.4.1",

--- a/tests/acceptance/auto-scroll-test.js
+++ b/tests/acceptance/auto-scroll-test.js
@@ -1,0 +1,106 @@
+import { module, test } from 'qunit';
+import { visit, find } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { drag }  from 'ember-sortable/test-support/helpers';
+
+function fakeDocumentContainer(){
+
+  let testingContainer = document.getElementById('ember-testing-container')
+  let testingApp = document.getElementById('ember-testing')
+
+  document.getElementById('ember-testing')
+
+  let originalStyle = {
+    containerHeight : testingContainer.style.height,
+    containerWidth : testingContainer.style.width,
+    containerOverflow : testingContainer.style.overflow,
+
+    appHeight : testingApp.style.height,
+    appWidth : testingApp.style.width
+  }
+
+
+  document.getElementById('ember-testing-container').style.height = 'auto';
+  document.getElementById('ember-testing-container').style.width = 'auto';
+  document.getElementById('ember-testing-container').style.overflow = 'visible';
+  document.getElementById('ember-testing').style.height = 'auto';
+  document.getElementById('ember-testing').style.height = 'auto';
+
+  return () => {
+    document.getElementById('ember-testing-container').style.height = originalStyle.containerHeight;
+    document.getElementById('ember-testing-container').style.width = originalStyle.containerWidth;
+    document.getElementById('ember-testing-container').style.overflow = originalStyle.containerOverflow;
+    document.getElementById('ember-testing').style.height = originalStyle.appHeight;
+    document.getElementById('ember-testing').style.height = originalStyle.appWidth;
+  }
+}
+
+module('Acceptance | container auto scroll', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    document.getElementById('ember-testing-container').scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  });
+
+  test('verticaly reordering can scroll his parent container (not document)', async function(assert) {
+    await visit('/docautoscroll');
+
+    let itemHeight = () => {
+      let item = find('[data-test-doc-auto-scroll-demo-item]');
+      const itemStyle = item.currentStyle || window.getComputedStyle(item);
+      return item.offsetHeight + parseInt(itemStyle.marginTop);
+    };
+
+    await drag('mouse', '[data-test-doc-auto-scroll-demo-item]', () => { return {dy: itemHeight() * 30 + 1, dx: undefined}});
+    assert.ok(document.getElementById('ember-testing-container').scrollTop, 'The container has scroll (top)')
+  });
+
+  test('horizontaly reordering can scroll his parent container (not document)', async function(assert) {
+    await visit('/docautoscroll?direction=x');
+
+    let itemWidth = () => {
+      let item = find('[data-test-doc-auto-scroll-demo-item]');
+      const itemStyle = item.currentStyle || window.getComputedStyle(item);
+      return item.offsetWidth + parseInt(itemStyle.marginLeft);
+    };
+
+    await drag('mouse', '[data-test-doc-auto-scroll-demo-item]', () => { return {dy: undefined, dx: itemWidth() * 30 + 1}});
+    assert.ok(document.getElementById('ember-testing-container').scrollLeft, 'The container has scroll (left)')
+  });
+
+
+  test('verticaly reordering can scroll his parent container (document)', async function(assert) {
+
+    let restoreTestingContainer = fakeDocumentContainer();
+
+    await visit('/docautoscroll');
+
+    let itemHeight = () => {
+      let item = find('[data-test-doc-auto-scroll-demo-item]');
+      const itemStyle = item.currentStyle || window.getComputedStyle(item);
+      return item.offsetHeight + parseInt(itemStyle.marginTop);
+    };
+
+    await drag('mouse', '[data-test-doc-auto-scroll-demo-item]', () => { return {dy: itemHeight() * 30 + 1, dx: undefined}});
+    assert.ok(document.documentElement.scrollTop, 'The document has scroll (top)')
+    restoreTestingContainer()
+  });
+
+  test('horizontaly reordering can scroll his parent container (document)', async function(assert) {
+
+    let restoreTestingContainer = fakeDocumentContainer();
+
+    await visit('/docautoscroll?direction=x');
+
+    let itemWidth = () => {
+      let item = find('[data-test-doc-auto-scroll-demo-item]');
+      const itemStyle = item.currentStyle || window.getComputedStyle(item);
+      return item.offsetWidth + parseInt(itemStyle.marginLeft);
+    };
+
+    await drag('mouse', '[data-test-doc-auto-scroll-demo-item]', () => { return {dy: undefined, dx: itemWidth() * 30 + 1}});
+    assert.ok(document.documentElement.scrollLeft, 'The document has scroll (left)')
+    restoreTestingContainer()
+  });
+});

--- a/tests/dummy/app/controllers/docautoscroll.js
+++ b/tests/dummy/app/controllers/docautoscroll.js
@@ -1,0 +1,14 @@
+import Controller from '@ember/controller';
+import { equal } from '@ember/object/computed';
+import { set } from '@ember/object';
+
+export default Controller.extend({
+  queryParams: ['direction'],
+  direction: 'y',
+  isVertical: equal('direction', 'y'),
+  actions: {
+    updateItems(newOrder) {
+      set(this, 'model.items', newOrder);
+    }
+  }
+})

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ const Router = EmberRouter.extend({
 
 Router.map(function() {
   this.route('modifier');
+  this.route('docautoscroll');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/docautoscroll.js
+++ b/tests/dummy/app/routes/docautoscroll.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { A as a } from '@ember/array';
+
+export default Route.extend({
+  model() {
+    return {
+      items: a([...Array(99).keys()].map((_, idx) => `Item #${idx+1}`))
+    };
+  }
+});

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -67,7 +67,7 @@
   color: pink;
 }
 
-.vertical-spacing-demo .sortable-item, .vertical-distance-demo .sortable-item {
+.vertical-spacing-demo .sortable-item, .vertical-distance-demo .sortable-item, .vertical-doc-auto-scroll-demo .sortable-item {
   display: block;
   position: relative;
   background: #58D3F7;
@@ -86,7 +86,17 @@
   white-space: nowrap;
 }
 
-.horizontal-demo .sortable-item {
+.horizontal-doc-auto-scroll-demo {
+  white-space: nowrap;
+}
+.horizontal-doc-auto-scroll-demo ol{
+  padding-left: 0px;
+}
+.horizontal-doc-auto-scroll-demo .sortable-item{
+  width: 70px;
+}
+
+.horizontal-demo .sortable-item, .horizontal-doc-auto-scroll-demo .sortable-item{
   display: inline-block;
   position: relative;
   cursor: move;

--- a/tests/dummy/app/templates/docautoscroll.hbs
+++ b/tests/dummy/app/templates/docautoscroll.hbs
@@ -1,0 +1,13 @@
+<section class={{if isVertical "vertical-doc-auto-scroll-demo" "horizontal-doc-auto-scroll-demo" }}>
+  <ol data-test-doc-auto-scroll-demo-group
+    {{sortable-group
+      onChange=(action "updateItems")
+      direction=direction}}
+  >
+    {{#each model.items as |item|}}
+      <li data-test-doc-auto-scroll-demo-item {{sortable-item model=item}}>
+        {{item}}
+      </li>
+    {{/each}}
+  </ol>
+</section>

--- a/tests/dummy/app/templates/docautoscroll.hbs
+++ b/tests/dummy/app/templates/docautoscroll.hbs
@@ -5,7 +5,7 @@
       direction=direction}}
   >
     {{#each model.items as |item|}}
-      <li data-test-doc-auto-scroll-demo-item {{sortable-item model=item}}>
+      <li data-test-doc-auto-scroll-demo-item {{sortable-item disableCheckScrollBounds=false model=item}}>
         {{item}}
       </li>
     {{/each}}


### PR DESCRIPTION
This PR aims to fix #233

The "real" fix concerns only the file [system/scroll-container.js](https://github.com/adopted-ember-addons/ember-sortable/blob/762761e37030fcdaa76aa50c65523d3fa062b9c9/addon/system/scroll-container.js)

I wrote a new route in dummy app to allow some acceptance tests. I also added a new argument on `sortable-item` component & modifier to enable the check about scroll bounds when runing test suite.

& last, the acceptance test about "auto scroll" when container is the document includes a hack to "unlock" the height of `#ember-testing` div and allowing scrolling on the document element. 
I personnaly dislike this kind of "hack", but I didn't found any other way to test it.
If someone have an idea... I'm all ears.