### PR TITLE
Use a service to track group/item state

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ ember install ember-sortable
       <span class="handle" {{sortable-handle}}>&varr;</span>
     </li>
   {{/each}}
-</ol>>
+</ol>
 ```
 
 The `onChange` action is called with two arguments:
@@ -123,7 +123,7 @@ The modifier version does not support `groupModel`, use the currying of `action`
       <span class="handle" {{sortable-handle}}>&varr;</span>
     </li>
   {{/each}}
-</ol>>
+</ol>
 ```
 
 
@@ -270,6 +270,39 @@ modifier
     <span class="handle" {{sortable-handle}}>&varr;</span>
   </li>
 ```
+
+### Multiple Ember-Sortables renders simultaneously (Modifier version) 
+
+The modifier version uses a service behind the scenes for communication between the group and the items and to maintain state. It does this seemlessly when the elements are rendered on the screen. However, if there are two sortables rendered at the same time, either in the same component or different components, the state management does not know which items belong to which group.
+
+Both the `{{sortable-group}}` and `{{sortable-item}}` take an additional argument `groupName`. Should you encounter this conflict, assign a `groupName` to the group and items. You only need to do this for one of the sortables in conflict, but you can on both if you wish.
+
+```hbs
+<ol {{sortable-group groupName="products" onChange=(action "reorderItems" model)}}>
+  {{#each model.items as |modelItem|}}
+    <li {{sortable-item groupName="products" model=modelItem}}>
+      {{modelItem.name}}
+      <span class="handle" {{sortable-handle}}>&varr;</span>
+    </li>
+  {{/each}}
+</ol>
+```
+
+Ensure that the same name is passed to both the group and the items, this would be best accomplished by creating property on the component and referring to that property. If you are able to use the `{{#let}}` helper (useful in template only components), using `{{#let}}` makes the usage clearer.
+
+```hbs
+{{#let "products" as | myGroupName |}}
+  <ol {{sortable-group groupName=myGroupName onChange=(action "reorderItems" model)}}>
+    {{#each model.items as |modelItem|}}
+      <li {{sortable-item groupName=myGroupName model=modelItem}}>
+        {{modelItem.name}}
+        <span class="handle" {{sortable-handle}}>&varr;</span>
+      </li>
+    {{/each}}
+  </ol>
+{{/let}}
+```
+
 
 ### Disabling Drag (Experimental)
 `sortable-item` (component and modifier) exposes an optional `isDraggingDisabled` flag that you can use to disable `drag` on the particular item.

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -13,6 +13,7 @@ import scrollParent from "../system/scroll-parent";
 import {getBorderSpacing} from "../utils/css-calculation";
 import { buildWaiter } from 'ember-test-waiters';
 import {inject as service} from '@ember/service';
+import {assert} from '@ember/debug';
 
 const sortableItemWaiter = buildWaiter("sortable-item-waiter");
 
@@ -49,6 +50,7 @@ export default class SortableItemModifier extends Modifier {
   get sortableGroup() {
     if (this._sortableGroup === undefined) {
       this._sortableGroup = this.sortableService.fetchGroup(this.groupName);
+      assert(`No sortable group named ${this.groupName} found. Please check that the groups and items have the same groupName`, this._sortableGroup !== undefined)
     }
     return this._sortableGroup.groupModifier;
   }

--- a/addon/services/ember-sortable.js
+++ b/addon/services/ember-sortable.js
@@ -1,0 +1,95 @@
+import Service from '@ember/service';
+
+export default class EmberSortableService extends Service {
+
+  /**
+   * Internal State for any groups currently in DOM
+   *
+   * {
+   *   groupName: {
+   *     groupModifier: object,
+   *     items: []
+   *   }
+   * }
+   * @type {{}}
+   */
+  groups = {
+
+  };
+
+  /**
+   * Register a new group with the service
+   *
+   * @param {String} groupName
+   * @param {SortableGroupModifier} groupModifier
+   */
+  registerGroup(groupName, groupModifier) {
+    if (this.groups[groupName] === undefined) {
+      this.groups[groupName] = {
+        groupModifier: groupModifier,
+        items: []
+      }
+    } else {
+      this.groups[groupName].groupModifier = groupModifier;
+    }
+  }
+
+  /**
+   * De-register a group with the service
+   *
+   * @param {String} groupName
+   */
+  deregisterGroup(groupName) {
+    delete this.groups[groupName];
+  }
+
+  /**
+   * Register an item with this group
+   *
+   * @method registerItem
+   * @param {String} groupName
+   * @param {SortableItemModifier} item
+   */
+  registerItem(groupName, item) {
+    let groupDef = this.fetchGroup(groupName);
+    let items = groupDef.items;
+
+    if (items.indexOf(item) === -1) {
+      items = [...items, item];
+    }
+
+    groupDef.items = items;
+  }
+
+  /**
+   De-register an item with this group.
+
+   @method deregisterItem
+   @param groupName
+   @param item
+   */
+  deregisterItem(groupName, item) {
+    let groupDef = this.fetchGroup(groupName);
+    let items = groupDef.items;
+
+    const index = items.indexOf(item);
+    if (index !== -1) {
+      let newItems = [...items.slice(0, index), ...items.slice(index + 1)];
+      groupDef.items = newItems;
+    }
+  }
+
+  /**
+   * Fetch a group definition
+   *
+   * @param {String} groupName
+   * @returns {*}
+   */
+  fetchGroup(groupName) {
+    if (this.groups[groupName] === undefined) {
+      this.registerGroup(groupName, undefined);
+    }
+
+    return this.groups[groupName];
+  }
+}

--- a/tests/acceptance/smoke-modifier-test.js
+++ b/tests/acceptance/smoke-modifier-test.js
@@ -98,7 +98,7 @@ module('Acceptance | smoke modifier', function(hooks) {
       order[4]
     );
 
-    assert.equal(verticalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(verticalContents(), 'Tres Dos Uno Cuatro Cinco', "25");
     assert.equal(horizontalContents(), 'Tres Dos Uno Cuatro Cinco');
     assert.equal(tableContents(), 'Tres Dos Uno Cuatro Cinco');
     assert.equal(scrollableContents(), 'Tres Dos Uno Cuatro Cinco');

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -33,10 +33,11 @@
       <ol data-test-vertical-demo-group
         {{sortable-group
           onChange=this.updateDifferentSizedModels
+          groupName="verticle-size"
         }}
       >
         {{#each this.differentSizedModels as |item|}}
-          <li data-test-vertical-demo-item class="word-break" {{sortable-item model=item}}>
+          <li data-test-vertical-demo-item class="word-break" {{sortable-item model=item groupName="verticle-size"}}>
             <label for="demo-input">{{item}}</label>
             <input id="demo-input" type="text">
             <span data-item={{item}} data-test-vertical-demo-handle class="handle" {{sortable-handle}}>
@@ -56,10 +57,11 @@
           onChange=this.update
           itemVisualClass=this.itemVisualClass
           handleVisualClass=this.handleVisualClass
+          groupName="horizontal"
         }}
       >
         {{#each this.model.items as |item|}}
-          <li data-test-horizontal-demo-handle tabindex={{"0"}} {{sortable-item model=item}}>
+          <li data-test-horizontal-demo-handle tabindex={{"0"}} {{sortable-item model=item groupName="horizontal"}}>
             {{item-presenter item=item}}
           </li>
         {{/each}}
@@ -77,9 +79,9 @@
             <th>Item</th>
           </tr>
         </thead>
-        <tbody {{sortable-group onChange=this.update}}>
+        <tbody {{sortable-group onChange=this.update groupName="table"}}>
           {{#each this.model.items as |item|}}
-            <tr data-test-table-demo-item class="handle" {{sortable-item model=item }}>
+            <tr data-test-table-demo-item class="handle" {{sortable-item model=item groupName="table"}}>
               <td><span data-test-table-demo-handle data-item={{item}} class="handle">&vArr;</span></td>
               <td>{{item}}</td>
             </tr>
@@ -91,9 +93,9 @@
     <section class="vertical-spacing-demo">
       <h3>Vertical with 15px spacing</h3>
 
-      <ol {{sortable-group onChange=this.update}}>
+      <ol {{sortable-group onChange=this.update groupName="verticle-15"}}>
         {{#each this.model.items as |item|}}
-          <li {{sortable-item model=item spacing=15}} tabindex="0">
+          <li {{sortable-item model=item spacing=15 groupName="verticle-15"}} tabindex="0">
             {{item}}
             <span data-test-vertical-spacing-demo-handle data-item={{item}}>
             </span>
@@ -105,9 +107,9 @@
     <section class="vertical-distance-demo">
       <h3>Vertical with distance set to 15</h3>
 
-      <ol {{sortable-group onChange=this.update}}>
+      <ol {{sortable-group onChange=this.update groupName="verticle-15d"}}>
         {{#each this.model.items as |item|}}
-          <li data-test-vertical-distance-demo-handle {{sortable-item model=item distance=15}} tabindex="0">
+          <li data-test-vertical-distance-demo-handle {{sortable-item model=item distance=15 groupName="verticle-15d"}} tabindex="0">
             {{item}}
             <span data-item={{item}}>
             </span>
@@ -120,9 +122,9 @@
       <h3>Scrollable</h3>
 
       <div class="sortable-container">
-        <ol {{sortable-group onChange=this.update}}>
+        <ol {{sortable-group onChange=this.update groupName="scrollable"}}>
           {{#each this.model.items as |item|}}
-            <li data-test-scrollable-demo-handle {{sortable-item model=item}}>
+            <li data-test-scrollable-demo-handle {{sortable-item model=item groupName="scrollable"}}>
               {{item}}
               <span class="handle" data-item={{item}} {{sortable-handle}}>
                 <span>&vArr;</span>
@@ -148,21 +150,18 @@
   <section class="vertical-demo">
     <h3>Vertical</h3>
 
-    {{#sortable-group
-            data-test-vertical-demo-group-no-css
-            handleVisualClass=handleVisualClass onChange=(action "update")
-            model=model.items as |group|
-    }}
-      {{#each group.model as |item|}}
-        {{#group.item data-test-vertical-demo-item-no-css tagName="li" model=item  as |groupItem|}}
+    <ol {{sortable-group data-test-vertical-demo-group-no-css
+                         onChange=this.update handleVisualClass=handleVisualClass
+                         groupName="verticle-no-css"}}>
+      {{#each this.model.items as |item|}}
+        <li data-test-scrollable-demo-handle-item-no-css {{sortable-item model=item groupName="verticle-no-css"}}>
           {{item}}
-          {{#groupItem.handle data-test-vertical-demo-handle-no-css class="handle"}}
-            <span data-item={{item}}>
-              <span>&vArr;</span>
-            </span>
-          {{/groupItem.handle}}
-        {{/group.item}}
+          <span class="handle" data-test-vertical-demo-handle-no-css data-item={{item}} {{sortable-handle}}>
+            <span>&vArr;</span>
+          </span>
+        </li>
       {{/each}}
-    {{/sortable-group}}
+    </ol>
+
   </section>
 </article>

--- a/tests/integration/modifiers/sortable-group-test.js
+++ b/tests/integration/modifiers/sortable-group-test.js
@@ -1,0 +1,67 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { settled, find, findAll, render } from '@ember/test-helpers';
+import {set} from '@ember/object';
+import { reorder }  from 'ember-sortable/test-support/helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Modifier | sortable-group', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('Works with items added after render', async function(assert) {
+    this.items = ['Uno', 'Dos', 'Tres'];
+
+    this.update = (items) => {
+      set(this, 'items', items);
+    };
+
+    await render(hbs`
+      <ol id="test-list" {{sortable-group onChange=this.update}}>
+        {{#each this.items as |item|}}
+          <li {{sortable-item model=item}}>{{item}}</li>
+        {{/each}}
+      </ol>
+    `);
+
+    set(this, 'items', [...this.items, 'Quatro']);
+
+    await settled();
+
+    let order = findAll('li');
+
+    await reorder(
+      'mouse',
+      'li',
+      order[3],
+      order[1],
+      order[0],
+      order[2],
+    );
+    assert.equal(contents('#test-list'), 'Quatro Dos Uno Tres');
+
+    set(this, 'items', this.items.slice(1));
+
+    await settled();
+
+    await reorder(
+      'mouse',
+      'li',
+      order[2],
+      order[1],
+      order[0]
+    );
+
+    assert.equal(contents('#test-list'), 'Tres Dos Uno');
+  });
+
+
+  function contents(selector) {
+    return find(selector)
+      .textContent
+      .replace(/⇕/g, '')
+      .replace(/\s+/g, ' ')
+      .replace(/^\s+/, '')
+      .replace(/\s+$/, '');
+  }
+
+});

--- a/tests/unit/services/ember-sortable-test.js
+++ b/tests/unit/services/ember-sortable-test.js
@@ -1,0 +1,74 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import {isArray} from '@ember/array';
+
+module('Unit | Service | ember-sortable', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.sortableService = this.owner.lookup('service:ember-sortable@ember-sortable');
+
+    // While not truly a group modifier, the service just registers whatever object is passed
+    this.groupModifier = {
+      stuff: ""
+    };
+
+    // While not truly an item modifier, the service just registers whatever object is passed
+    this.sortableItem = {
+      itemStuff: ""
+    };
+
+    this.groupName = "GroupName";
+    this.unregisteredGroupName = "UnregisteredName";
+  });
+
+  test('Registers/Deregisters a group', function(assert) {
+
+    this.sortableService.registerGroup(this.groupName, this.groupModifier);
+    let groupDef = this.sortableService.groups[this.groupName];
+
+    assert.ok(groupDef.groupModifier === this.groupModifier);
+    assert.ok(isArray(groupDef.items));
+
+    this.sortableService.deregisterGroup("unregisteredGroupName");
+    groupDef = this.sortableService.groups[this.groupName];
+    // did not effect registered name
+    assert.ok(groupDef.groupModifier === this.groupModifier);
+
+    this.sortableService.deregisterGroup(this.groupName);
+    groupDef = this.sortableService.groups[this.groupName];
+    assert.ok(groupDef === undefined);
+
+   });
+
+  test('Registers/Deregisters an item', function(assert) {
+
+    this.sortableService.registerItem(this.groupName, this.sortableItem);
+    let groupDef = this.sortableService.fetchGroup(this.groupName);
+
+    assert.ok(isArray(groupDef.items));
+    assert.ok(groupDef.items.includes(this.sortableItem));
+
+    this.sortableService.deregisterItem(this.unregisteredGroupName, this.sortableItem);
+    groupDef = this.sortableService.fetchGroup(this.groupName);
+    assert.ok(groupDef.items.includes(this.sortableItem));
+
+    this.sortableService.deregisterItem(this.groupName, this.sortableItem);
+    assert.ok(isArray(groupDef.items));
+    assert.notOk(groupDef.items.includes(this.sortableItem));
+  });
+
+  test('Fetch a group', function(assert) {
+
+    let groupDef = this.sortableService.fetchGroup(this.groupName);
+
+    assert.ok(groupDef, "Creates a group if one is not previously registered");
+    assert.ok(isArray(groupDef.items));
+
+    let groupDef2 = this.sortableService.fetchGroup(this.groupName);
+    assert.ok(groupDef === groupDef2, "Fetches the correct group is one exists");
+
+
+  });
+
+});


### PR DESCRIPTION
This PR uses a service instead of item after render to register and maintain state.

This does require that is there is more than one group in the DOM that both the group and items contain an additional param of the group name.