### PR TITLE
Fixes "'removeChild' of null" in SortableGroupModifier willRemove method

### DIFF
--- a/addon/modifiers/sortable-group.js
+++ b/addon/modifiers/sortable-group.js
@@ -732,7 +732,9 @@ export default class SortableGroupModifier extends Modifier {
 
   willRemove() {
     // todo cleanup the announcer
-    this.announcer.parentNode.removeChild(this.announcer);
+    if(this.announcer.parentNode) {
+      this.announcer.parentNode.removeChild(this.announcer);
+    }
     this.removeEventListener();
   }
 


### PR DESCRIPTION
In some cases the willRemove method is run after the page has navigated away. Therefore we should check if the announcer still has a parentNode before trying to remove it.