### PR TITLE
Updating github actions ci to use lts ember versions in ember try

### DIFF
--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        scenario: [ember-lts-3.8, ember-lts-3.12, ember-lts-3.15, ember-lts-3.18]
+        scenario: [ember-lts-3.8, ember-lts-3.12, ember-lts-3.16, ember-lts-3.20]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 10

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -28,18 +28,18 @@ module.exports = function() {
           }
         },
         {
-          name: 'ember-lts-3.15',
+          name: 'ember-lts-3.16',
           npm: {
             devDependencies: {
-              'ember-source': '~3.15.0'
+              'ember-source': '~3.16.0'
             }
           }
         },
         {
-          name: 'ember-lts-3.18',
+          name: 'ember-lts-3.20',
           npm: {
             devDependencies: {
-              'ember-source': '~3.18.0'
+              'ember-source': '~3.20.0'
             }
           }
         },


### PR DESCRIPTION
Updated to using LTS versions, `3.12`, `3.16`, and `3.20`. Keep `3.8` around for backward compatibility check even tho it is no longer LTS.