### PR TITLE
Revert "Merge pull request #403 from adopted-ember-addons/dependabot/npm_and_yarn/ini-1.3.7

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5813,9 +5813,8 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@^1.3.4, ini@~1.3.0:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
-  integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 inline-source-map-comment@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
This reverts commit 468ee0c653260d65bf6cc4035dfdee29bb68bb70 (from #403), reversing changes made to 3ccf38b7581639e35e12ca64758fc42a956f00af. The merge was done in error, and it breaks against Ember 3.20 LTS for reasons not yet clear.