### PR TITLE
Allowed waiting on an optional promise before resetting items

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -267,12 +267,20 @@ export default Component.extend({
     this.set('moves', []);
     this._disableKeyboardReorderMode();
     this._tearDownA11yApplicationContainer();
-    this._updateItems();
+
+    let promise;
     if (groupModel !== NO_MODEL) {
-      this.onChange(groupModel, itemModels, selectedModel)
+      promise = this.onChange(groupModel, itemModels, selectedModel)
     } else {
-      this.onChange(itemModels, selectedModel);
+      promise = this.onChange(itemModels, selectedModel);
     }
+
+    if (promise && typeof promise.finally === 'function') {
+      promise.finally(() => this._updateItems());
+    } else {
+      this._updateItems();
+    }
+
     this._updateItemVisualIndicators(_selectedItem, false);
     this._updateHandleVisualIndicators(_selectedItem, false);
     this._resetItemSelection();
@@ -380,11 +388,17 @@ export default Component.extend({
       draggedModel = get(draggedItem, 'model');
     }
 
-    this._updateItems();
+    let promise;
     if (groupModel !== NO_MODEL) {
-      this.onChange(groupModel, itemModels, draggedModel);
+      promise = this.onChange(groupModel, itemModels, draggedModel);
     } else {
-      this.onChange(itemModels, draggedModel);
+      promise = this.onChange(itemModels, draggedModel);
+    }
+
+    if (promise && typeof promise.finally === 'function') {
+      promise.finally(() => this._updateItems());
+    } else {
+      this._updateItems();
     }
   },
 

--- a/addon/modifiers/sortable-group.js
+++ b/addon/modifiers/sortable-group.js
@@ -652,15 +652,17 @@ export default class SortableGroupModifier extends Modifier {
       draggedModel = draggedItem.model;
     }
 
-    this._updateItems();
-    this._onChange(itemModels, draggedModel);
+    const promise = this._onChange(itemModels, draggedModel);
+    if (promise && typeof promise.finally === 'function') {
+      promise.finally(() => this._updateItems);
+    } else {
+      this._updateItems();
+    }
   }
 
   @action
   _onChange(itemModels, draggedModel) {
-    if (this.onChange) {
-      this.onChange(itemModels, draggedModel);
-    }
+    return this.onChange && this.onChange(itemModels, draggedModel);
   }
 
   /**

--- a/tests/acceptance/smoke-component-test.js
+++ b/tests/acceptance/smoke-component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, find, findAll, triggerKeyEvent, focus, blur } from '@ember/test-helpers';
+import { visit, find, findAll, triggerKeyEvent, focus, blur, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { drag, reorder }  from 'ember-sortable/test-support/helpers';
 import { ENTER_KEY_CODE, SPACE_KEY_CODE, ESCAPE_KEY_CODE, ARROW_KEY_CODES } from "ember-sortable/test-support/utils/keyboard";
@@ -181,6 +181,23 @@ module('Acceptance | smoke component', function(hooks) {
     assert.equal(horizontalContents(), 'Tres Dos Uno Cuatro Cinco');
     assert.equal(tableContents(), 'Tres Dos Uno Cuatro Cinco');
     assert.equal(scrollableContents(), 'Tres Dos Uno Cuatro Cinco');
+  });
+
+  test('reordering with a delayed onChange update', async function(assert) {
+    await visit('/');
+
+    assert.equal(delayedContents(), 'Uno Dos Tres Cuatro Cinco');
+
+    const item = find('[data-test-delayed-demo-handle]');
+    const style = window.getComputedStyle(item);
+    const height = item.offsetHeight + parseInt(style.marginTop);
+    await drag('mouse', '[data-test-delayed-demo-handle]', () => { return { dy: height * 2 + 1, dx: undefined }});
+
+    assert.equal(delayedContents(), 'Uno Dos Tres Cuatro Cinco');
+
+    await waitFor('[data-test-delayed-update-finished]');
+
+    assert.equal(delayedContents(), 'Dos Uno Tres Cuatro Cinco');
   });
 
   module('[A11y] Reordering with keyboard events', function() {
@@ -589,6 +606,10 @@ module('Acceptance | smoke component', function(hooks) {
 
   function scrollableContents() {
     return contents('.scrollable-demo ol');
+  }
+
+  function delayedContents() {
+    return contents('.delayed-demo ol');
   }
 
   function contents(selector) {

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,7 +1,12 @@
 import Controller from '@ember/controller';
-import { set } from '@ember/object';
+import { computed, set } from '@ember/object';
 import { A as a } from '@ember/array';
 
+function timeout(ms) {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(), ms);
+  });
+}
 
 export default Controller.extend({
   init() {
@@ -47,6 +52,13 @@ export default Controller.extend({
     });
   },
 
+  delayedUpdateFinished: computed('model.{delayedUpdateStarts,delayedUpdateFinishes}', function() {
+    const { delayedUpdateStarts, delayedUpdateFinishes } = this.get('model');
+    return delayedUpdateStarts !== undefined &&
+      delayedUpdateFinishes !== undefined &&
+      delayedUpdateStarts === delayedUpdateFinishes;
+  }),
+
   actions: {
     updateDifferentSizedModels(newOrder) {
       set(this, 'differentSizedModels', newOrder);
@@ -54,6 +66,17 @@ export default Controller.extend({
     update(newOrder, draggedModel) {
       set(this, 'model.items', a(newOrder));
       set(this, 'model.dragged', draggedModel);
+    },
+    async delayedUpdate(newOrder, draggedModel) {
+      const startCount = this.get('model.delayedUpdateStarts') || 0;
+      set(this, 'model.delayedUpdateStarts', startCount + 1);
+
+      await timeout(50);
+
+      set(this, 'model.items', a(newOrder));
+      set(this, 'model.dragged', draggedModel);
+      const finishCount = this.get('model.delayedUpdateFinishes') || 0;
+      set(this, 'model.delayedUpdateFinishes', finishCount + 1);
     }
   }
 })

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -170,6 +170,30 @@
   color: pink;
 }
 
+.delayed-demo .sortable-item {
+  display: block;
+  position: relative;
+  background: pink;
+  margin: 4px 0;
+}
+
+.delayed-demo .sortable-item.is-dragging {
+  background: red;
+}
+
+.delayed-demo .sortable-item.is-dropping {
+  background: #f66;
+  z-index: 10;
+}
+
+.delayed-demo .sortable-item .handle {
+  display: block;
+  position: absolute;
+  top: 0; right: 0; bottom: 0;
+  background: rgba(71, 1, 1, 0.5);
+  color: pink;
+}
+
 #ember-testing {
   transform: none !important;
 }

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -139,6 +139,35 @@
       </div>
     </section>
 
+    <section class="delayed-demo">
+      <h3>Delayed</h3>
+
+      {{#sortable-group
+        data-test-delayed-demo-group
+        tagName="ol"
+        a11yAnnouncementConfig=a11yAnnouncementConfig
+        a11yItemName="spanish number"
+        itemVisualClass=itemVisualClass
+        handleVisualClass=handleVisualClass onChange=(action "delayedUpdate")
+        model=model.items as |group|
+      }}
+        {{#each group.model as |item|}}
+          {{#group.item data-test-delayed-demo-item tagName="li" model=item  as |groupItem|}}
+            {{item}}
+            {{#groupItem.handle data-test-delayed-demo-handle class="handle"}}
+              <span data-item={{item}}>
+                <span>&vArr;</span>
+              </span>
+            {{/groupItem.handle}}
+          {{/group.item}}
+        {{/each}}
+      {{/sortable-group}}
+
+      {{#if this.delayedUpdateFinished}}
+        <p data-test-delayed-update-finished>Delayed update finished!</p>
+      {{/if}}
+    </section>
+
     {{#if model.dragged}}
       <p>Just dragged {{model.dragged}}</p>
     {{/if}}


### PR DESCRIPTION
### Summary
This is a fantastic addon and a slick implementation of drag-and-drop sorting! However, as my team and I were using it, we found we wanted to tie the "drop" action to a network request to persist the new order to the server. While straightforward when using an ORM like Ember Data (just update position, which updates the view, and then call `save()`), it's more complicated if the underlying data is immutable. Ideally, when using something like Apollo to communicate with a GraphQL API, you'd be able to "hold" the rearranged items in-place in the UI while the mutation is sent, finally updating the data powering the view (automatically when Apollo updates its cache) after the request completes.

This PR is an attempt to address this use-case by means of an optional promise returned from the `onChange` action. If the action returns a promise, then we wait for it to either resolve or reject before we schedule the reset of the items' positions as managed by `ember-sortable`.

For existing usage, there should be effectively no change. Although the order of calling `onChange()` and `_updateItems()` is reversed at their respective call-sites, because `_updateItems()` schedules its UI work using the Ember runloop, nothing should get out-of-sync, as `onChange` would continue to be run as part of the `action` queue. For the case where `onChange` returns a promise, however, `_updateItems()` would now be called as part of its `finally()` callback, only resetting the items' positioning/CSS after the promise either rejects or resolves. My hope was that the change could truly be additive, not interfering with the way the addon functions for the vast majority of users.

All the tests that currently pass continue to pass with these changes -- I wasn't able to track down the failures on Ember 3.20, but they seem to be happening even on the latest release -- but neither was I quite sure how to test the new functionality. Since the DOM itself isn't rearranged until after the underlying data is modified, it's not straightforward to check that the rearrangement is "holding" until the promise resolves. If there's a way that would make sense to be able to check this, I'd be happy to add a test case or two using that method. 🙂

Thanks for your consideration!