### PR TITLE
Set default values for itemVisualClass  and a11yAnnouncementConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ There are 4 modes during keyboard navigation:
 #### User configurable
 ##### Screen Reader
 - **a11yItemName**
-  a name for the item.
+  a name for the item. Defaults to `item`.
 - **a11yAnnouncementConfig**
   a map of `action enums` to `functions` that takes the following `config`, which is exposed by `sortable-group`.
 ```javascript
@@ -378,7 +378,7 @@ a11yAnnounceConfig = {
 ```
 and returns a `string` constructed from the `config`.
 
-**Example**
+**Default value**
 ```javascript
 {
   ACTIVATE: function({ a11yItemName, index, maxLength, direction }) {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ ember install ember-sortable
 
 ## Usage
 
-### component 
+### component
 ```hbs
 {{! app/templates/my-route.hbs }}
 
@@ -52,7 +52,7 @@ $ ember install ember-sortable
 {{/sortable-group}}
 ```
 
-### modifier 
+### modifier
 ```hbs
 {{! app/templates/my-route.hbs }}
 
@@ -180,7 +180,7 @@ modifier
 
 ### CSS, Animation
 
-Sortable items can be in one of three states: default, dragging, dropping.
+Sortable items can be in one of four states: default, dragging, dropping, and activated.
 The classes look like this:
 
 ```html
@@ -190,6 +190,8 @@ The classes look like this:
 <li class="sortable-item is-dragging">...</li>
 <!-- Dropping -->
 <li class="sortable-item is-dropping">...</li>
+<!-- Keyboard -->
+<li class="sortable-item is-activated">...</li>
 ```
 
 In our [example app.css](tests/dummy/app/styles/app.css) we apply a
@@ -224,6 +226,9 @@ slightly different colour:
   z-index: 10;
 }
 ```
+
+If the user presses space to activate and move an item via the keyboard, `is-activated` is added. Once the user drops the item it is
+removed. Use this class to add a visual indicator that the item is selected and being manipulated.
 
 ### Drag Actions
 
@@ -405,7 +410,7 @@ and returns a `string` constructed from the `config`.
   This class will be added to the `sortable-handle` during `ACTIVATE` and `MOVE` operations. This allows you to add custom styles such as `visual arrows` via `pseudo` classes.
 
 - **itemVisualClass**
-  This class will be added to the `sortable-item` during `ACTIVATE` and `MOVE` operations. This is needed to creating a `visual indicator` that mimics `focus` b/c the native `focus` is on the container.
+  This class will be added to the `sortable-item` during `ACTIVATE` and `MOVE` operations. The default class added is `is-activated`. This is needed to creating a `visual indicator` that mimics `focus` b/c the native `focus` is on the container.
 
 ## Testing
 

--- a/addon/modifiers/sortable-group.js
+++ b/addon/modifiers/sortable-group.js
@@ -10,6 +10,7 @@ import {
   isUpArrowKey
 } from "../utils/keyboard";
 import {ANNOUNCEMENT_ACTION_TYPES} from "../utils/constant";
+import { defaultA11yAnnouncementConfig } from "../utils/defaults";
 import { run } from '@ember/runloop';
 import {inject as service} from '@ember/service';
 
@@ -73,7 +74,6 @@ export default class SortableGroupModifier extends Modifier {
   /**
    * @property an object containing functions for producing screen reader announcements
    * @type {Object}
-   * @default null
    * @example
    * {
    *  MOVE: function() {},
@@ -83,7 +83,7 @@ export default class SortableGroupModifier extends Modifier {
    * }
    */
   get a11yAnnouncementConfig() {
-    return this.args.named.a11yAnnouncementConfig || NO_MODEL;
+    return this.args.named.a11yAnnouncementConfig || defaultA11yAnnouncementConfig;
   }
 
   get itemVisualClass() {
@@ -91,7 +91,7 @@ export default class SortableGroupModifier extends Modifier {
   }
 
   get a11yItemName() {
-    return this.args.named.a11yItemName;
+    return this.args.named.a11yItemName || 'item';
   }
   /** End of a11y properties */
 

--- a/addon/modifiers/sortable-group.js
+++ b/addon/modifiers/sortable-group.js
@@ -87,7 +87,7 @@ export default class SortableGroupModifier extends Modifier {
   }
 
   get itemVisualClass() {
-    return this.args.named.itemVisualClass;
+    return this.args.named.itemVisualClass || "is-activated";
   }
 
   get a11yItemName() {

--- a/addon/utils/defaults.js
+++ b/addon/utils/defaults.js
@@ -1,0 +1,25 @@
+export const defaultA11yAnnouncementConfig = {
+  ACTIVATE({ a11yItemName, index, maxLength, direction }) {
+    let message = `${a11yItemName} at position, ${index + 1} of ${maxLength}, is activated to be repositioned.`;
+
+    if (direction === 'y') {
+      message += 'Press up and down keys to change position,';
+    }
+    else {
+      message += 'Press left and right keys to change position,';
+    }
+
+    message += ' Space to confirm new position, Escape to cancel.';
+
+    return message;
+  },
+  MOVE({ a11yItemName, index, maxLength, delta }) {
+    return `${a11yItemName} is moved to position, ${index + 1 + delta} of ${maxLength}. Press Space to confirm new position, Escape to cancel.`;
+  },
+  CONFIRM({ a11yItemName }) {
+    return `${a11yItemName} is successfully repositioned.`;
+  },
+  CANCEL({ a11yItemName }) {
+    return `Cancelling ${a11yItemName} repositioning`;
+  },
+};


### PR DESCRIPTION
This adds reasonable defaults for `itemVisualClass` and `a11yAnnouncementConfig` so sortable can be used with less customization required on each invocation. 

There as already default values for `is-dragging` and `is-dropping` used by mouse re-ordering, so it made sense to follow that pattern and use `is-activated` for the keyboard version. 

The `a11yAnnouncementConfig` is copied from the example docs.