### PR TITLE
Require ember-decorators-polyfill to be installed by client app

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ For modifiers, please read this [migration guide](/MIGRATION_GUIDE_MODIFIERS.md)
 
 In version 2.0.0+, our `closest` polyfill seems to break some app's `production` build. To mitigate this, the `closest` polyfill will only enabled if it doesn't break the `production` build (if the `polyfill` file is recognized by the build). Affected apps will need to supply their own [closest](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill) polyfill to ensure compatibility with IE. This issue is tracked [here](https://github.com/adopted-ember-addons/ember-sortable/issues/333).
 
+We require yhe `ember-decorators-polyfill` to be installed if you are using this addon with versions of Ember < 3.10.0.
+
 Version 1.0 depends upon the availability of 2D CSS transforms.
 Check [the matrix on caniuse.com](http://caniuse.com/#feat=transforms2d)
 to see if your target browsers are compatible.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For modifiers, please read this [migration guide](/MIGRATION_GUIDE_MODIFIERS.md)
 
 In version 2.0.0+, our `closest` polyfill seems to break some app's `production` build. To mitigate this, the `closest` polyfill will only enabled if it doesn't break the `production` build (if the `polyfill` file is recognized by the build). Affected apps will need to supply their own [closest](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill) polyfill to ensure compatibility with IE. This issue is tracked [here](https://github.com/adopted-ember-addons/ember-sortable/issues/333).
 
-We require yhe `ember-decorators-polyfill` to be installed if you are using this addon with versions of Ember < 3.10.0.
+We require the `ember-decorators-polyfill` to be installed if you are using this addon with versions of Ember < 3.10.0.
 
 Version 1.0 depends upon the availability of 2D CSS transforms.
 Check [the matrix on caniuse.com](http://caniuse.com/#feat=transforms2d)

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -15,7 +15,8 @@ module.exports = function() {
           name: 'ember-lts-3.8',
           npm: {
             devDependencies: {
-              'ember-source': '~3.8.0'
+              'ember-source': '~3.8.0',
+              'ember-decorators-polyfill': '^1.1.1',
             }
           }
         },

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
     }
 
     var checker = new VersionChecker(this);
-    var emberVersion = checker.forEmber();
+    var emberVersion = checker.for('ember-source');
 
     if (emberVersion.lt('3.10.0')) {
       this.ui.writeWarnLine('ember-sortable requires the ember-decorator-polyfill. Please add it to your `package.json`.');

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
   name: require('./package').name,
@@ -12,6 +13,13 @@ module.exports = {
     // So guarding this with a if polyfill exists.
     if (fs.existsSync('vendor/polyfills/closest.js')) {
       app.import('vendor/polyfills/closest.js', { prepend: true});
+    }
+
+    var checker = new VersionChecker(this);
+    var emberVersion = checker.forEmber();
+
+    if (emberVersion.lt('3.10.0')) {
+      this.ui.writeWarnLine('ember-sortable requires the ember-decorator-polyfill. Please add it to your `package.json`.');
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ember/render-modifiers": "^1.0.2",
     "ember-cli-babel": "^7.11.1",
     "ember-cli-htmlbars": "^5.0.0",
-    "ember-decorators-polyfill": "^1.1.1",
+    "ember-cli-version-checker": "^5.1.2",
     "ember-get-config": "^0.3.0",
     "ember-modifier": "^2.1.0",
     "ember-test-selectors": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,6 +3957,15 @@ ember-cli-version-checker@^5.1.1:
     semver "^7.3.2"
     silent-error "^1.1.1"
 
+ember-cli-version-checker@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz#649c7b6404902e3b3d69c396e054cea964911ab0"
+  integrity sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==
+  dependencies:
+    resolve-package-path "^3.1.0"
+    semver "^7.3.4"
+    silent-error "^1.1.1"
+
 ember-cli@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.13.1.tgz#8daefb108130740cd79ad7e4e1c9138fb1f7313d"
@@ -4063,15 +4072,6 @@ ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1:
     babel-plugin-debug-macros "^0.2.0"
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
-
-ember-decorators-polyfill@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.1.tgz#6ff8e57a516e04c583451305574020c34e6ad4bc"
-  integrity sha512-ZIB3uNcquNyRm+eWUbDeeE5BtH/D7oXIX9pdiEHx4TXaTnAY6z4wDrw6Ge0xP9wx/nlC4Qd/i8rdlwBOT5C6lw==
-  dependencies:
-    ember-cli-babel "^7.1.2"
-    ember-cli-version-checker "^3.1.3"
-    ember-compatibility-helpers "^1.2.0"
 
 ember-destroyable-polyfill@^2.0.2:
   version "2.0.2"
@@ -6895,6 +6895,13 @@ lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -8655,6 +8662,13 @@ semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+semver@^7.3.4:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -9982,6 +9996,11 @@ yallist@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yam@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This removes the ember-decorator-polyfill dependency and instead adds a console warning if the consuming app doesn't have it installed. The issue here is that the polyfill breaks older versions of ember-data when used with the newest versions of ember-source. For users stuck on old versions of ember-data due to performance regressions this can be an issue. 

Fixes #378