### PR TITLE
Allow sortable-group to be disabled

### DIFF
--- a/addon/modifiers/sortable-group.js
+++ b/addon/modifiers/sortable-group.js
@@ -707,14 +707,21 @@ export default class SortableGroupModifier extends Modifier {
   }
 
   didReceiveArguments() {
+    this.removeEventListener();
+
+    if (this.args.named.disabled) {
+      this.sortableService.disableGroup(this.groupName);
+      return;
+    }
+
+    this.sortableService.enableGroup(this.groupName);
+    this.addEventListener();
   }
 
   didUpdateArguments() {
   }
 
   didInstall() {
-    this.addEventListener();
-
     this.announcer = this._createAnnouncer();
     this.element.insertAdjacentElement('afterend', this.announcer);
 

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -63,6 +63,9 @@ export default class SortableItemModifier extends Modifier {
   @reads("sortableGroup.direction")
   direction;
 
+  @reads("sortableGroup.disabled")
+  disabled;
+
   @service('ember-sortable@ember-sortable')
   sortableService;
 
@@ -239,6 +242,9 @@ export default class SortableItemModifier extends Modifier {
 
   @action
   keyDown(event) {
+    // Prevents keyboard sorting if group is disabled
+    if (this.disabled) { return; }
+
     // If the event is coming from within the item, we do not want to activate keyboard reorder mode.
     if (event.target === this.handleElement || event.target === this.element) {
       this.sortableGroup.activateKeyDown(this);
@@ -296,6 +302,9 @@ export default class SortableItemModifier extends Modifier {
    * @private
    */
   _primeDrag(startEvent) {
+    // Prevent dragging if the entire group is disabled
+    if (this.disabled) { return; }
+
     // Prevent dragging if the sortable-item is disabled.
     if (this.isDraggingDisabled) {
       return;

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -63,11 +63,17 @@ export default class SortableItemModifier extends Modifier {
   @reads("sortableGroup.direction")
   direction;
 
-  @reads("sortableGroup.disabled")
-  disabled;
-
   @service('ember-sortable@ember-sortable')
   sortableService;
+
+  /**
+   * True if the entire sortable-group has been disabled
+   * @type Boolean;
+   */
+  get disabled() {
+    let group = this.sortableService.fetchGroup(this.groupName);
+    return group.disabled;
+  }
 
   /**
    * This is the group name used to keep groups separate if there are more than one on the screen at a time.

--- a/addon/services/ember-sortable.js
+++ b/addon/services/ember-sortable.js
@@ -26,6 +26,7 @@ export default class EmberSortableService extends Service {
   registerGroup(groupName, groupModifier) {
     if (this.groups[groupName] === undefined) {
       this.groups[groupName] = {
+        disabled: false,
         groupModifier: groupModifier,
         items: []
       }
@@ -41,6 +42,24 @@ export default class EmberSortableService extends Service {
    */
   deregisterGroup(groupName) {
     delete this.groups[groupName];
+  }
+
+  /**
+   * Disable a group and prevent all reorder activity
+   *
+   * @param {String} groupName
+   */
+  disableGroup(groupName) {
+    this.groups[groupName].disabled = true;
+  }
+
+  /**
+   * Enable a group and allow reorder
+   *
+   * @param {String} groupName
+   */
+  enableGroup(groupName) {
+    this.groups[groupName].disabled = false;
   }
 
   /**

--- a/tests/dummy/app/controllers/modifier.js
+++ b/tests/dummy/app/controllers/modifier.js
@@ -1,8 +1,11 @@
 import Controller from '@ember/controller';
 import { set, action } from '@ember/object';
+import { tracked } from '@glimmer/tracking'
 
 
 export default class ModifierController extends Controller {
+  @tracked disabled = false;
+
   differentSizedModels =  [
     'A',
     'B'.repeat(100),
@@ -51,5 +54,10 @@ export default class ModifierController extends Controller {
   update(newOrder, draggedModel) {
     set(this, 'model.items', newOrder);
     set(this, 'model.dragged', draggedModel);
+  }
+
+  @action
+  toggleDisabled() {
+    this.disabled = !this.disabled;
   }
 }

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,6 +3,10 @@
     <h2>Ember Sortable</h2>
   </header>
 
+  <LinkTo @route="index">Components</LinkTo>
+  |
+  <LinkTo @route="modifier">Modifiers</LinkTo>
+
   <main>
     <section class="vertical-demo">
       <h3>Vertical</h3>
@@ -172,3 +176,4 @@
     {{/sortable-group}}
   </section>
 </article>
+

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -174,9 +174,11 @@
   <section class="vertical-demo">
     <h3>Disabled</h3>
 
-    <button {{on "click" this.toggleDisabled}}>
-      Disabled: {{this.disabled}}
-    </button>
+    <div>
+      <button {{on "click" this.toggleDisabled}}>
+        Disabled: {{this.disabled}}
+      </button>
+    </div>
 
     <ol
       {{sortable-group

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -3,6 +3,10 @@
     <h2>Ember Sortable</h2>
   </header>
 
+  <LinkTo @route="index">Components</LinkTo>
+  |
+  <LinkTo @route="modifier">Modifiers</LinkTo>
+
   <main>
     <section class="vertical-demo">
       <h3>Vertical</h3>
@@ -163,5 +167,34 @@
       {{/each}}
     </ol>
 
+  </section>
+</article>
+
+<article class="demo">
+  <section class="vertical-demo">
+    <h3>Disabled</h3>
+
+    <button {{on "click" this.toggleDisabled}}>
+      Disabled: {{this.disabled}}
+    </button>
+
+    <ol
+      {{sortable-group
+        disabled=this.disabled
+        groupName="disabled"
+        onChange=this.update
+      }}
+    >
+      {{#each model.items as |item|}}
+        <li {{sortable-item model=item groupName="disabled"}}>
+          {{item}}
+          {{#unless this.disabled}}
+            <span class="handle" {{sortable-handle}} data-item={{item}}>
+              <span>&vArr;</span>
+            </span>
+          {{/unless}}
+        </li>
+      {{/each}}
+    </ol>
   </section>
 </article>

--- a/tests/integration/modifiers/sortable-group-test.js
+++ b/tests/integration/modifiers/sortable-group-test.js
@@ -54,6 +54,39 @@ module('Integration | Modifier | sortable-group', function(hooks) {
     assert.equal(contents('#test-list'), 'Tres Dos Uno');
   });
 
+  test('you can disabled a group', async function (assert) {
+    this.items = ['Uno', 'Dos', 'Tres', 'Quatro'];
+
+    this.update = () => {
+      assert.ok(false, 'onChange was called while group is disabled');
+    };
+
+    this.disabled = false;
+
+    await render(hbs`
+      <ol id="test-list" {{sortable-group disabled=this.disabled onChange=this.update}}>
+        {{#each this.items as |item|}}
+          <li {{sortable-item model=item}}>{{item}}</li>
+        {{/each}}
+      </ol>
+    `);
+
+    this.set('disabled', true);
+
+    let order = findAll('li');
+
+    await reorder(
+      'mouse',
+      'li',
+      order[3],
+      order[1],
+      order[0],
+      order[2],
+    );
+
+    assert.ok(true, 'Reorder prevented');
+  });
+
   test('Announcer has appropriate text for user actions', async function (assert) {
     this.items = ['Uno', 'Dos', 'Tres'];
 


### PR DESCRIPTION
Right now it is not possible to conditionally add an element modifier. This can lead to some messy code to work around this. In this PR I add a disabled argument to `sortable-group` that will prevent any sorting by either keyboard or mouse when set to true. Very useful if there is a switch the user has to flip to enable sorting.