### PR TITLE
Refactor disabled mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ modifier
   </li>
 ```
 
-### Multiple Ember-Sortables renders simultaneously (Modifier version) 
+### Multiple Ember-Sortables renders simultaneously (Modifier version)
 
 The modifier version uses a service behind the scenes for communication between the group and the items and to maintain state. It does this seemlessly when the elements are rendered on the screen. However, if there are two sortables rendered at the same time, either in the same component or different components, the state management does not know which items belong to which group.
 
@@ -326,7 +326,7 @@ Ensure that the same name is passed to both the group and the items, this would 
 
 
 ### Disabling Drag (Experimental)
-`sortable-item` (component and modifier) exposes an optional `isDraggingDisabled` flag that you can use to disable `drag` on the particular item.
+`sortable-item` (component and modifier) exposes an optional `disabled` (previously `isDraggingDisabled`) flag that you can use to disable reordering for that particular item.
 This flag is intended as an utility to make your life easier with 3 main benefits:
 1. You can now specify which `sortable-item` are not intended to be draggable/sortable.
 2. You do not have to duplicate the `sortable-item` UI just for the purpose of disabling the `sorting` behavior.
@@ -350,8 +350,8 @@ component
   an ordered list, `ol`, by default.
 - `sortable-item`
   a list item, `li`, by default.
-  
-The modifier version can be attached to to any element that makes sense, 
+
+The modifier version can be attached to to any element that makes sense,
 
 ##### Keyboard Navigation
 There are 4 modes during keyboard navigation:

--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ modifier
 <li {{sortable-item distance=30}}>
 ```
 
+### Disabling reordering
+
+The `disabled` attribute allows you to disable sorting for the entire group and its child items. While
+set to true the user won't be able to reorder using the mouse of keyboard.
+
+modifier
+```hbs
+<li {{sortable-group disabled=true}}>
+```
+
 ### CSS, Animation
 
 Sortable items can be in one of four states: default, dragging, dropping, and activated.

--- a/README.md
+++ b/README.md
@@ -326,8 +326,10 @@ Ensure that the same name is passed to both the group and the items, this would 
 
 
 ### Disabling Drag (Experimental)
-`sortable-item` (component and modifier) exposes an optional `disabled` (previously `isDraggingDisabled`) flag that you can use to disable reordering for that particular item.
+`sortable-item` (component and modifier) exposes an optional `disabled` (previously `isDraggingDisabled`) flag that you can use to disable reordering for that particular item. Disabling and item won't prevent it from changing position in the array. The user can still move other non-disabled items to over it.
+
 This flag is intended as an utility to make your life easier with 3 main benefits:
+
 1. You can now specify which `sortable-item` are not intended to be draggable/sortable.
 2. You do not have to duplicate the `sortable-item` UI just for the purpose of disabling the `sorting` behavior.
 3. Allows you to access the entire list of `models` for your `onChange` action, which can now be a mix of sortable and non-sortable items.

--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ modifier
 
 ### Disabling reordering
 
-The `disabled` attribute allows you to disable sorting for the entire group and its child items. While
-set to true the user won't be able to reorder using the mouse of keyboard.
+The `disabled` attribute allows you to disable sorting for the entire group and its child items.
 
 modifier
 ```hbs

--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -138,7 +138,15 @@ export default Component.extend({
   spacing: 0,
 
   /**
-    Removes the ability for the current item to be dragged
+    Removes the ability for the current item to be reordered
+    @property disabled
+    @type Boolean
+    @default false
+  */
+  disabled: false,
+
+  /**
+    Deprecated. Removes the ability for the current item to be reordered
     @property isDraggingDisabled
     @type Boolean
     @default false
@@ -267,7 +275,7 @@ export default Component.extend({
    */
   _primeDrag(startEvent) {
     // Prevent dragging if the sortable-item is destroying or is disabled.
-    if (this.isDestroying || this.get('isDraggingDisabled')) {
+    if (this.isDestroying || this.isDisabled) {
       return;
     }
 

--- a/addon/modifiers/sortable-group.js
+++ b/addon/modifiers/sortable-group.js
@@ -707,14 +707,21 @@ export default class SortableGroupModifier extends Modifier {
   }
 
   didReceiveArguments() {
+    this.removeEventListener();
+
+    if (this.args.named.disabled) {
+      this.sortableService.disableGroup(this.groupName);
+      return;
+    }
+
+    this.sortableService.enableGroup(this.groupName);
+    this.addEventListener();
   }
 
   didUpdateArguments() {
   }
 
   didInstall() {
-    this.addEventListener();
-
     this.announcer = this._createAnnouncer();
     this.element.insertAdjacentElement('afterend', this.announcer);
 

--- a/addon/modifiers/sortable-group.js
+++ b/addon/modifiers/sortable-group.js
@@ -54,6 +54,10 @@ export default class SortableGroupModifier extends Modifier {
   isRetainingFocus = false;
   /** End of keyboard utils */
 
+  get disabled() {
+    return this.args.named.disabled || false;
+  }
+
   /** Start of a11y properties */
   /**
    * @property an object containing different classes for visual indicators
@@ -709,12 +713,10 @@ export default class SortableGroupModifier extends Modifier {
   didReceiveArguments() {
     this.removeEventListener();
 
-    if (this.args.named.disabled) {
-      this.sortableService.disableGroup(this.groupName);
+    if (this.disabled) {
       return;
     }
 
-    this.sortableService.enableGroup(this.groupName);
     this.addEventListener();
   }
 

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -23,7 +23,7 @@ const sortableItemWaiter = buildWaiter("sortable-item-waiter");
  * Modifier to mark an element as an item to be reordered
  *
  * @param {Object} model The model that this item will represent
- * @param {boolean} [isDraggingDisabled=false] Set to true to make this item not draggable
+ * @param {boolean} [disabled=false] Set to true to make this item not sortable
  * @param {Function}  [onDragStart] An optional callback for when dragging starts.
  * @param {Function}  [onDragStop] An optional callback for when dragging stops.
  *
@@ -64,7 +64,7 @@ export default class SortableItemModifier extends Modifier {
   direction;
 
   @reads("sortableGroup.disabled")
-  disabled;
+  groupDisabled;
 
   @service('ember-sortable@ember-sortable')
   sortableService;
@@ -102,13 +102,13 @@ export default class SortableItemModifier extends Modifier {
   }
 
   /**
-   Removes the ability for the current item to be dragged
-   @property isDraggingDisabled
+   Removes the ability for the current item to be sorted
+   @property disabled
    @type  boolean
    @default false
    */
-  get isDraggingDisabled() {
-    return this.args.named.isDraggingDisabled || false;
+  get isDisabled() {
+    return this.groupDisabled || this.args.named.disabled || this.args.named.isDraggingDisabled || false;
   }
 
   /**
@@ -220,10 +220,7 @@ export default class SortableItemModifier extends Modifier {
   isBusy;
 
   /**
-   Removes the ability for the current item to be dragged
-   @property isDraggingDisabled
-   @type  boolean
-   @default false
+   @property disableCheckScrollBounds
    */
   get disableCheckScrollBounds() {
     return this.args.named.disableCheckScrollBounds != undefined ? this.args.named.disableCheckScrollBounds : isTesting;
@@ -242,8 +239,7 @@ export default class SortableItemModifier extends Modifier {
 
   @action
   keyDown(event) {
-    // Prevents keyboard sorting if group is disabled
-    if (this.disabled) { return; }
+    if (this.isDisabled) { return; }
 
     // If the event is coming from within the item, we do not want to activate keyboard reorder mode.
     if (event.target === this.handleElement || event.target === this.element) {
@@ -302,13 +298,7 @@ export default class SortableItemModifier extends Modifier {
    * @private
    */
   _primeDrag(startEvent) {
-    // Prevent dragging if the entire group is disabled
-    if (this.disabled) { return; }
-
-    // Prevent dragging if the sortable-item is disabled.
-    if (this.isDraggingDisabled) {
-      return;
-    }
+    if (this.isDisabled) { return; }
 
     if (this.handleElement && !startEvent.target.closest(this.handle)) {
       return;

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -63,6 +63,9 @@ export default class SortableItemModifier extends Modifier {
   @reads("sortableGroup.direction")
   direction;
 
+  @reads("sortableGroup.disabled")
+  disabled;
+
   @service('ember-sortable@ember-sortable')
   sortableService;
 
@@ -239,6 +242,9 @@ export default class SortableItemModifier extends Modifier {
 
   @action
   keyDown(event) {
+    // Prevents keyboard sorting if group is disabled
+    if (this.disabled) { return; }
+
     // If the event is coming from within the item, we do not want to activate keyboard reorder mode.
     if (event.target === this.handleElement || event.target === this.element) {
       this.sortableGroup.activateKeyDown(this);
@@ -296,6 +302,9 @@ export default class SortableItemModifier extends Modifier {
    * @private
    */
   _primeDrag(startEvent) {
+    // Prevent dragging if the entire group is disabled
+    if (this.disabled) { return; }
+
     // Prevent dragging if the sortable-item is disabled.
     if (this.isDraggingDisabled) {
       return;

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -63,17 +63,11 @@ export default class SortableItemModifier extends Modifier {
   @reads("sortableGroup.direction")
   direction;
 
+  @reads("sortableGroup.disabled")
+  disabled;
+
   @service('ember-sortable@ember-sortable')
   sortableService;
-
-  /**
-   * True if the entire sortable-group has been disabled
-   * @type Boolean;
-   */
-  get disabled() {
-    let group = this.sortableService.fetchGroup(this.groupName);
-    return group.disabled;
-  }
 
   /**
    * This is the group name used to keep groups separate if there are more than one on the screen at a time.

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -63,11 +63,17 @@ export default class SortableItemModifier extends Modifier {
   @reads("sortableGroup.direction")
   direction;
 
-  @reads("sortableGroup.disabled")
-  disabled;
-
   @service('ember-sortable@ember-sortable')
   sortableService;
+
+  /**
+   * True if the entire sortable-group has been disabled
+   * @type Boolean;
+   */
+  get disabled() {
+    let group = this.sortableService.fetchGroup(this.groupName);
+    return group.disabled;
+  }
 
   /**
    * This is the group name used to keep groups separate if there are more than one on the screen at a time.

--- a/addon/services/ember-sortable.js
+++ b/addon/services/ember-sortable.js
@@ -26,7 +26,6 @@ export default class EmberSortableService extends Service {
   registerGroup(groupName, groupModifier) {
     if (this.groups[groupName] === undefined) {
       this.groups[groupName] = {
-        disabled: false,
         groupModifier: groupModifier,
         items: []
       }

--- a/addon/services/ember-sortable.js
+++ b/addon/services/ember-sortable.js
@@ -45,24 +45,6 @@ export default class EmberSortableService extends Service {
   }
 
   /**
-   * Disable a group and prevent all reorder activity
-   *
-   * @param {String} groupName
-   */
-  disableGroup(groupName) {
-    this.groups[groupName].disabled = true;
-  }
-
-  /**
-   * Enable a group and allow reorder
-   *
-   * @param {String} groupName
-   */
-  enableGroup(groupName) {
-    this.groups[groupName].disabled = false;
-  }
-
-  /**
    * Register an item with this group
    *
    * @method registerItem

--- a/addon/services/ember-sortable.js
+++ b/addon/services/ember-sortable.js
@@ -26,6 +26,7 @@ export default class EmberSortableService extends Service {
   registerGroup(groupName, groupModifier) {
     if (this.groups[groupName] === undefined) {
       this.groups[groupName] = {
+        disabled: false,
         groupModifier: groupModifier,
         items: []
       }
@@ -41,6 +42,24 @@ export default class EmberSortableService extends Service {
    */
   deregisterGroup(groupName) {
     delete this.groups[groupName];
+  }
+
+  /**
+   * Disable a group and prevent all reorder activity
+   *
+   * @param {String} groupName
+   */
+  disableGroup(groupName) {
+    this.groups[groupName].disabled = true;
+  }
+
+  /**
+   * Enable a group and allow reorder
+   *
+   * @param {String} groupName
+   */
+  enableGroup(groupName) {
+    this.groups[groupName].disabled = false;
   }
 
   /**

--- a/tests/dummy/app/controllers/modifier.js
+++ b/tests/dummy/app/controllers/modifier.js
@@ -1,8 +1,11 @@
 import Controller from '@ember/controller';
 import { set, action } from '@ember/object';
+import { tracked } from '@glimmer/tracking'
 
 
 export default class ModifierController extends Controller {
+  @tracked disabled = false;
+
   differentSizedModels =  [
     'A',
     'B'.repeat(100),
@@ -51,5 +54,10 @@ export default class ModifierController extends Controller {
   update(newOrder, draggedModel) {
     set(this, 'model.items', newOrder);
     set(this, 'model.dragged', draggedModel);
+  }
+
+  @action
+  toggleDisabled() {
+    this.disabled = !this.disabled;
   }
 }

--- a/tests/dummy/app/helpers/eq.js
+++ b/tests/dummy/app/helpers/eq.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import { isEqual as emberIsEqual } from '@ember/utils';
+
+export function isEqual([a, b]) {
+  return emberIsEqual(a, b);
+}
+
+export default helper(isEqual);

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,9 +3,13 @@
     <h2>Ember Sortable</h2>
   </header>
 
-  <LinkTo @route="index">Components</LinkTo>
+  {{#link-to "index"}}
+    Components
+  {{/link-to}}
   |
-  <LinkTo @route="modifier">Modifiers</LinkTo>
+  {{#link-to "modifier"}}
+    Modifiers
+  {{/link-to}}
 
   <main>
     <section class="vertical-demo">

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,6 +3,10 @@
     <h2>Ember Sortable</h2>
   </header>
 
+  <LinkTo @route="index">Components</LinkTo>
+  |
+  <LinkTo @route="modifier">Modifiers</LinkTo>
+
   <main>
     <section class="vertical-demo">
       <h3>Vertical</h3>
@@ -172,3 +176,4 @@
     {{/sortable-group}}
   </section>
 </article>
+

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -174,9 +174,11 @@
   <section class="vertical-demo">
     <h3>Disabled</h3>
 
-    <button {{on "click" this.toggleDisabled}}>
-      Disabled: {{this.disabled}}
-    </button>
+    <div>
+      <button {{on "click" this.toggleDisabled}}>
+        Disabled: {{this.disabled}}
+      </button>
+    </div>
 
     <ol
       {{sortable-group

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -176,7 +176,7 @@
 
 <article class="demo">
   <section class="vertical-demo">
-    <h3>Disabled</h3>
+    <h3>Disabled (group)</h3>
 
     <div>
       <button {{on "click" this.toggleDisabled}}>
@@ -199,6 +199,33 @@
               <span>&vArr;</span>
             </span>
           {{/unless}}
+        </li>
+      {{/each}}
+    </ol>
+  </section>
+
+  <section class="vertical-demo">
+    <h3>Vertical (disabled items)</h3>
+
+    <ol data-test-vertical-disabled-item-demo-group
+      {{sortable-group
+        onChange=this.update
+        a11yAnnouncementConfig=this.a11yAnnouncementConfig
+        a11yItemName="spanish number"
+        itemVisualClass=this.itemVisualClass
+        handleVisualClass=this.handleVisualClass
+        groupName="vertical-disabled-item"
+      }}
+    >
+      {{#each model.items as |item|}}
+        <li data-test-vertical-disabled-item-demo-item {{sortable-item model=item groupName="vertical-disabled-item" disabled=(eq item "Dos")}}>
+          {{item}}
+          {{#if (eq item "Dos")}}
+            (disabled)
+          {{/if}}
+          <span class="handle" data-test-vertical-disabled-item-demo-handle {{sortable-handle}} data-item={{item}}>
+            <span>&vArr;</span>
+          </span>
         </li>
       {{/each}}
     </ol>

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -3,9 +3,13 @@
     <h2>Ember Sortable</h2>
   </header>
 
-  <LinkTo @route="index">Components</LinkTo>
+  {{#link-to "index"}}
+    Components
+  {{/link-to}}
   |
-  <LinkTo @route="modifier">Modifiers</LinkTo>
+  {{#link-to "modifier"}}
+    Modifiers
+  {{/link-to}}
 
   <main>
     <section class="vertical-demo">

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -3,6 +3,10 @@
     <h2>Ember Sortable</h2>
   </header>
 
+  <LinkTo @route="index">Components</LinkTo>
+  |
+  <LinkTo @route="modifier">Modifiers</LinkTo>
+
   <main>
     <section class="vertical-demo">
       <h3>Vertical</h3>
@@ -163,5 +167,34 @@
       {{/each}}
     </ol>
 
+  </section>
+</article>
+
+<article class="demo">
+  <section class="vertical-demo">
+    <h3>Disabled</h3>
+
+    <button {{on "click" this.toggleDisabled}}>
+      Disabled: {{this.disabled}}
+    </button>
+
+    <ol
+      {{sortable-group
+        disabled=this.disabled
+        groupName="disabled"
+        onChange=this.update
+      }}
+    >
+      {{#each model.items as |item|}}
+        <li {{sortable-item model=item groupName="disabled"}}>
+          {{item}}
+          {{#unless this.disabled}}
+            <span class="handle" {{sortable-handle}} data-item={{item}}>
+              <span>&vArr;</span>
+            </span>
+          {{/unless}}
+        </li>
+      {{/each}}
+    </ol>
   </section>
 </article>

--- a/tests/integration/modifiers/sortable-group-test.js
+++ b/tests/integration/modifiers/sortable-group-test.js
@@ -54,6 +54,39 @@ module('Integration | Modifier | sortable-group', function(hooks) {
     assert.equal(contents('#test-list'), 'Tres Dos Uno');
   });
 
+  test('you can disabled a group', async function (assert) {
+    this.items = ['Uno', 'Dos', 'Tres', 'Quatro'];
+
+    this.update = () => {
+      assert.ok(false, 'onChange was called while group is disabled');
+    };
+
+    this.disabled = false;
+
+    await render(hbs`
+      <ol id="test-list" {{sortable-group disabled=this.disabled onChange=this.update}}>
+        {{#each this.items as |item|}}
+          <li {{sortable-item model=item}}>{{item}}</li>
+        {{/each}}
+      </ol>
+    `);
+
+    this.set('disabled', true);
+
+    let order = findAll('li');
+
+    await reorder(
+      'mouse',
+      'li',
+      order[3],
+      order[1],
+      order[0],
+      order[2],
+    );
+
+    assert.ok(true, 'Reorder prevented');
+  });
+
   test('Announcer has appropriate text for user actions', async function (assert) {
     this.items = ['Uno', 'Dos', 'Tres'];
 


### PR DESCRIPTION
Builds on #428 

This adds a new `disabled` property to the item modifier and ensures that the item cannot be reordered via the keyboard. This deprecates the `isDraggingDisabled` property so it can be removed in 3.0. 