### PR TITLE
Update the table examples to be more proper

### DIFF
--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -23,7 +23,7 @@ export default Controller.extend({
       itemVisualClass: 'sortable-item--active',
       a11yAnnouncementConfig: {
         ACTIVATE: function({ a11yItemName, index, maxLength, direction }) {
-          let message = `${a11yItemName} at position, ${index + 1} of ${maxLength}, is activated to be repositioned. `;
+          let message = `${a11yItemName} at position, ${index + 1} of ${maxLength}, is activated to be repositioned.`;
           if (direction === 'y') {
             message += 'Press up and down keys to change position,';
           } else {

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -23,7 +23,7 @@ export default Controller.extend({
       itemVisualClass: 'sortable-item--active',
       a11yAnnouncementConfig: {
         ACTIVATE: function({ a11yItemName, index, maxLength, direction }) {
-          let message = `${a11yItemName} at position, ${index + 1} of ${maxLength}, is activated to be repositioned.`;
+          let message = `${a11yItemName} at position, ${index + 1} of ${maxLength}, is activated to be repositioned. `;
           if (direction === 'y') {
             message += 'Press up and down keys to change position,';
           } else {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -189,7 +189,6 @@
 .sortable-handle-down:after,
 .sortable-handle-left:before,
 .sortable-handle-right:after {
-  content: " ";
   position: absolute;
   left: 50%;
   margin-left: -4px;

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -102,7 +102,7 @@
 
       {{! template-lint-disable table-groups}}
       {{#sortable-group
-        tagName="tbody"
+        tagName="table"
         onChange=(action "update")
         a11yAnnouncementConfig=a11yAnnouncementConfig
         a11yItemName="spanish number"
@@ -111,13 +111,13 @@
         model=model.items
         as |group|
       }}
-        <table>
-          <thead>
-            <tr>
-              <th></th>
-              <th>Item</th>
-            </tr>
-          </thead>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Item</th>
+          </tr>
+        </thead>
+        <tbody>
           {{#each group.model as |item|}}
             {{#group.item
               data-test-table-demo-item
@@ -137,7 +137,7 @@
               </td>
             {{/group.item}}
           {{/each}}
-        </table>
+        </tbody>
       {{/sortable-group}}
     </section>
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -122,14 +122,12 @@
             {{#group.item
               data-test-table-demo-item
               tagName="tr"
+              tabindex="0"
               model=item
-              as |groupItem|
             }}
               <td>
                 <span data-test-table-demo-handle data-item={{item}}>
-                  {{#groupItem.handle class="handle"}}
-                    &vArr;
-                  {{/groupItem.handle}}
+                  &vArr;
                 </span>
               </td>
               <td>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -13,11 +13,18 @@
         a11yAnnouncementConfig=a11yAnnouncementConfig
         a11yItemName="spanish number"
         itemVisualClass=itemVisualClass
-        handleVisualClass=handleVisualClass onChange=(action "update")
-        model=model.items as |group|
+        handleVisualClass=handleVisualClass
+        onChange=(action "update")
+        model=model.items
+        as |group|
       }}
         {{#each group.model as |item|}}
-          {{#group.item data-test-vertical-demo-item tagName="li" model=item  as |groupItem|}}
+          {{#group.item
+            data-test-vertical-demo-item
+            tagName="li"
+            model=item
+            as |groupItem|
+          }}
             {{item}}
             {{#groupItem.handle data-test-vertical-demo-handle class="handle"}}
               <span data-item={{item}}>
@@ -38,11 +45,19 @@
         a11yAnnouncementConfig=a11yAnnouncementConfig
         a11yItemName="spanish number"
         itemVisualClass=itemVisualClass
-        handleVisualClass=handleVisualClass onChange=(action "updateDifferentSizedModels")
-        model=differentSizedModels as |group|
+        handleVisualClass=handleVisualClass
+        onChange=(action "updateDifferentSizedModels")
+        model=differentSizedModels
+        as |group|
       }}
         {{#each group.model as |item|}}
-          {{#group.item data-test-vertical-demo-item class="word-break" tagName="li" model=item  as |groupItem|}}
+          {{#group.item
+            data-test-vertical-demo-item
+            class="word-break"
+            tagName="li"
+            model=item
+            as |groupItem|
+          }}
             <label for="demo-input">{{item}}</label>
             <input id="demo-input" type="text">
             {{#groupItem.handle data-test-vertical-demo-handle class="handle"}}
@@ -58,9 +73,23 @@
     <section class="horizontal-demo">
       <h3>Horizontal</h3>
 
-      {{#sortable-group data-test-horizontal-demo-group tagName="ol" itemVisualClass=itemVisualClass handleVisualClass=handleVisualClass direction="x" onChange=(action "update") model=model.items as |group|}}
+      {{#sortable-group
+        data-test-horizontal-demo-group
+        tagName="ol"
+        itemVisualClass=itemVisualClass
+        handleVisualClass=handleVisualClass
+        direction="x"
+        onChange=(action "update")
+        model=model.items
+        as |group|
+      }}
         {{#each group.model as |item|}}
-          {{#group.item data-test-horizontal-demo-handle tabindex="0" tagName="li" model=item}}
+          {{#group.item
+            data-test-horizontal-demo-handle
+            tabindex="0"
+            tagName="li"
+            model=item
+          }}
             {{item-presenter item=item}}
           {{/group.item}}
         {{/each}}
@@ -72,30 +101,55 @@
       <h3>Table</h3>
 
       {{! template-lint-disable table-groups}}
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th>Item</th>
-          </tr>
-        </thead>
-        {{#sortable-group tagName="tbody" onChange=(action "update") model=model.items as |group|}}
+      {{#sortable-group
+        tagName="tbody"
+        onChange=(action "update")
+        a11yAnnouncementConfig=a11yAnnouncementConfig
+        a11yItemName="spanish number"
+        itemVisualClass=itemVisualClass
+        handleVisualClass=handleVisualClass
+        model=model.items
+        as |group|
+      }}
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Item</th>
+            </tr>
+          </thead>
           {{#each group.model as |item|}}
-            {{#group.item data-test-table-demo-item tagName="tr" model=item handle=".handle" as |groupItem|}}
-              {{#groupItem.handle class="handle"}}
-                <td><span data-test-table-demo-handle data-item={{item}}>&vArr;</span></td>
-                <td>{{item}}</td>
-              {{/groupItem.handle}}
+            {{#group.item
+              data-test-table-demo-item
+              tagName="tr"
+              model=item
+              as |groupItem|
+            }}
+              <td>
+                <span data-test-table-demo-handle data-item={{item}}>
+                  {{#groupItem.handle class="handle"}}
+                    &vArr;
+                  {{/groupItem.handle}}
+                </span>
+              </td>
+              <td>
+                {{item}}
+              </td>
             {{/group.item}}
           {{/each}}
-        {{/sortable-group}}
-      </table>
+        </table>
+      {{/sortable-group}}
     </section>
 
     <section class="vertical-spacing-demo">
       <h3>Vertical with 15px spacing</h3>
 
-      {{#sortable-group tagName="ol" onChange=(action "update") model=model.items as |group|}}
+      {{#sortable-group
+        tagName="ol"
+        onChange=(action "update")
+        model=model.items
+        as |group|
+      }}
         {{#each group.model as |item|}}
           {{#group.item tabindex="0" tagName="li" model=item spacing=15}}
             {{item}}
@@ -109,9 +163,20 @@
     <section class="vertical-distance-demo">
       <h3>Vertical with distance set to 15</h3>
 
-      {{#sortable-group tagName="ol" onChange=(action "update") model=model.items as |group|}}
+      {{#sortable-group
+        tagName="ol"
+        onChange=(action "update")
+        model=model.items
+        as |group|
+      }}
         {{#each group.model as |item|}}
-          {{#group.item data-test-vertical-distance-demo-handle tagName="li" tabindex="0" model=item distance=15}}
+          {{#group.item
+            data-test-vertical-distance-demo-handle
+            tagName="li"
+            tabindex="0"
+            model=item
+            distance=15
+          }}
             {{item}}
             <span data-item={{item}}>
             </span>
@@ -124,9 +189,19 @@
       <h3>Scrollable</h3>
 
       <div class="sortable-container">
-        {{#sortable-group tagName="ol" onChange=(action "update") model=model.items as |group|}}
+        {{#sortable-group
+          tagName="ol"
+          onChange=(action "update")
+          model=model.items
+          as |group|
+        }}
           {{#each group.model as |item|}}
-            {{#group.item data-test-scrollable-demo-handle tagName="li" model=item as |groupItem|}}
+            {{#group.item
+              data-test-scrollable-demo-handle
+              tagName="li"
+              model=item
+              as |groupItem|
+            }}
               {{item}}
               {{#groupItem.handle}}
                 <span class="handle" data-item={{item}}>
@@ -146,7 +221,9 @@
 
   <footer>
     <p>
-      <a href="https://github.com/adopted-ember-addons/ember-sortable">View on GitHub</a>
+      <a href="https://github.com/adopted-ember-addons/ember-sortable">
+        View on GitHub
+      </a>
     </p>
   </footer>
 </article>
@@ -155,14 +232,24 @@
     <h3>Vertical</h3>
 
     {{#sortable-group
-            data-test-vertical-demo-group-no-css
-            handleVisualClass=handleVisualClass onChange=(action "update")
-            model=model.items as |group|
+      data-test-vertical-demo-group-no-css
+      handleVisualClass=handleVisualClass
+      onChange=(action "update")
+      model=model.items
+      as |group|
     }}
       {{#each group.model as |item|}}
-        {{#group.item data-test-vertical-demo-item-no-css tagName="li" model=item  as |groupItem|}}
+        {{#group.item
+          data-test-vertical-demo-item-no-css
+          tagName="li"
+          model=item
+          as |groupItem|
+        }}
           {{item}}
-          {{#groupItem.handle data-test-vertical-demo-handle-no-css class="handle"}}
+          {{#groupItem.handle
+            data-test-vertical-demo-handle-no-css
+            class="handle"
+          }}
             <span data-item={{item}}>
               <span>&vArr;</span>
             </span>

--- a/tests/dummy/app/templates/modifier.hbs
+++ b/tests/dummy/app/templates/modifier.hbs
@@ -72,17 +72,17 @@
       <h3>Table</h3>
 
       {{! template-lint-disable table-groups}}
-      <table>
+      <table {{sortable-group onChange=this.update groupName="table"}}>
         <thead>
           <tr>
             <th></th>
             <th>Item</th>
           </tr>
         </thead>
-        <tbody {{sortable-group onChange=this.update groupName="table"}}>
+        <tbody>
           {{#each this.model.items as |item|}}
-            <tr data-test-table-demo-item class="handle" {{sortable-item model=item groupName="table"}}>
-              <td><span data-test-table-demo-handle data-item={{item}} class="handle">&vArr;</span></td>
+            <tr tabindex="0" data-test-table-demo-item {{sortable-item model=item groupName="table"}}>
+              <td><span data-test-table-demo-handle data-item={{item}}>&vArr;</span></td>
               <td>{{item}}</td>
             </tr>
           {{/each}}


### PR DESCRIPTION
I was looking at the table example and realized that a11y wasn't being announced because the aria live region was being added into the table., not outside of the table breaking table semantics. I also made sure the table semantics are proper for both component and modifer versions.

Before:
<img width="547" alt="Screen Shot 2021-06-26 at 5 52 59 PM" src="https://user-images.githubusercontent.com/3947173/123532979-b4325c00-d6c6-11eb-8e56-5a535aa7fc78.png">

![before](https://user-images.githubusercontent.com/3947173/123532983-ba283d00-d6c6-11eb-8034-b203d12dcf86.gif)


After:
![after](https://user-images.githubusercontent.com/3947173/123532984-be545a80-d6c6-11eb-9e56-4f52d7d9f004.gif)

