### PR TITLE
Remove yarn test to push code

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,5 @@
 {
   "hooks": {
     "pre-commit": "yarn lint",
-    "pre-push": "yarn lint && yarn test"
   }
 }


### PR DESCRIPTION
The presence of testing the app when pushing code discourages contributions.  Also, everyone I know just does `--no-verify` to get around it. 