### PR TITLE
Deprecate use of components - SortableGroup, SortableItem and SortableHandle

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -13,6 +13,7 @@ import {
   isRightArrowKey,
 } from '../utils/keyboard';
 import {  ANNOUNCEMENT_ACTION_TYPES } from '../utils/constant';
+import { deprecate } from '@ember/debug';
 
 const a = A;
 const NO_MODEL = {};
@@ -129,6 +130,20 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+
+    deprecate(
+      'The <SortableGroup> component is deprecated.  Please use the modifier version {{sortable-group}}.',
+      false,
+      {
+        id: 'ember-sortable:sortable-group-component-deprecated',
+        until: '3.0.0',
+        for: 'ember-sortable',
+        since: {
+          available: '2.2.6',
+          enabled: '2.2.6',
+        },
+      }
+    );
 
     this._setGetterSetters();
     this.set('moves', []);

--- a/addon/components/sortable-handle.js
+++ b/addon/components/sortable-handle.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { deprecate } from '@ember/debug';
 
 /**
  * This component represents the handle of a `sortable-item`.
@@ -8,4 +9,22 @@ export default Component.extend({
   role: 'button',
   attributeBindings: ["dataSortableHandle:data-sortable-handle", "tabindex", "role"],
   dataSortableHandle: true,
+
+  init() {
+    this._super(...arguments);
+
+    deprecate(
+      'The <SortableHandle> component is deprecated.  Please use the modifier version {{sortable-handle}}.',
+      false,
+      {
+        id: 'ember-sortable:sortable-handle-component-deprecated',
+        until: '3.0.0',
+        for: 'ember-sortable',
+        since: {
+          available: '2.2.6',
+          enabled: '2.2.6',
+        },
+      }
+    );
+  },
 });

--- a/addon/components/sortable-item.js
+++ b/addon/components/sortable-item.js
@@ -12,6 +12,8 @@ import { DRAG_ACTIONS, ELEMENT_CLICK_ACTION, END_ACTIONS } from '../utils/consta
 import { getX, getY } from '../utils/coordinate';
 import { buildWaiter } from '@ember/test-waiters';
 import config from 'ember-get-config';
+import { deprecate } from '@ember/debug';
+
 const { environment } = config;
 const isTesting = environment === 'test';
 
@@ -158,6 +160,20 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+
+    deprecate(
+      'The <SortableItem> component is deprecated.  Please use the modifier version {{sortable-item}}.',
+      false,
+      {
+        id: 'ember-sortable:sortable-item-component-deprecated',
+        until: '3.0.0',
+        for: 'ember-sortable',
+        since: {
+          available: '2.2.6',
+          enabled: '2.2.6',
+        },
+      }
+    );
     this._setGetterSetters();
   },
 


### PR DESCRIPTION
ref https://github.com/adopted-ember-addons/ember-sortable/pull/377

## Description

Proposal to remove the existing components in favour of the modifier versions in the next major version release. The components are classic ember component and does not allow for much flexibility the the layout of the dom. The element modifiers on the other hand does not care about your markup, you can attach them to any DOM node you want. 

On top of that, the modifier versions don't require you to pass in the model so their api is a bit simpler. 