### PR TITLE
sortableGroup may be undefined

### DIFF
--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -66,11 +66,11 @@ export default class SortableItemModifier extends Modifier {
   }
 
   get direction() {
-    return this.sortableGroup.direction;
+    return this.sortableGroup?.direction;
   }
 
   get groupDisabled() {
-    return this.sortableGroup.disabled;
+    return this.sortableGroup?.disabled;
   }
 
   /**


### PR DESCRIPTION
the sortableGroup getter returns the groupModifier, which may be undefined.

when fetchGroup is called in the service: https://github.com/adopted-ember-addons/ember-sortable/blob/master/addon/services/ember-sortable.js#L87
undefined is passed as the modifier.

This requires that https://github.com/adopted-ember-addons/ember-sortable/blob/master/addon/modifiers/sortable-group.js#L729
is invoked, which has no protection around it :thinking: 
An alternative could be that we need to throw some protection around this situation from happening -- which I'm still investigating locally.
But these changes "get tests passing" in the ember-sortable@2 -> ember-sortable@3 upgrade PR I have internally.