### PR TITLE
perf: avoid creating callbacks for the destructor

### DIFF
--- a/addon/modifiers/sortable-group.js
+++ b/addon/modifiers/sortable-group.js
@@ -716,7 +716,7 @@ export default class SortableGroupModifier extends Modifier {
 
   constructor(owner, args) {
     super(owner, args);
-    registerDestructor(this, this.cleanup);
+    registerDestructor(this, cleanup);
   }
 
   modify(element /*, positional, named*/) {
@@ -738,14 +738,17 @@ export default class SortableGroupModifier extends Modifier {
 
     this.addEventListener();
   }
+}
 
-  cleanup(instance) {
-    // todo cleanup the announcer
-    if (instance.announcer.parentNode) {
-      instance.announcer.parentNode.removeChild(instance.announcer);
-    }
-    instance.removeEventListener();
-
-    instance.sortableService.deregisterGroup(instance.groupName, instance);
+/**
+ *
+ * @param {SortableGroupModifier} instance
+ */
+function cleanup(instance) {
+  // todo cleanup the announcer
+  if (instance.announcer.parentNode) {
+    instance.announcer.parentNode.removeChild(instance.announcer);
   }
+  instance.removeEventListener();
+  instance.sortableService.deregisterGroup(instance.groupName, instance);
 }

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -816,7 +816,7 @@ export default class SortableItemModifier extends Modifier {
 
   constructor(owner, args) {
     super(owner, args);
-    registerDestructor(this, this.cleanup);
+    registerDestructor(this, cleanup);
   }
 
   modify(element /*, positional, named*/) {
@@ -841,9 +841,13 @@ export default class SortableItemModifier extends Modifier {
       this.didSetup = true;
     }
   }
+}
 
-  cleanup(instance) {
-    instance.removeEventListener();
-    instance.sortableService.deregisterItem(instance.groupName, instance);
-  }
+/**
+ *
+ * @param {SortableItemModifier} instance
+ */
+function cleanup(instance) {
+  instance.removeEventListener();
+  instance.sortableService.deregisterItem(instance.groupName, instance);
 }


### PR DESCRIPTION
Extract `cleanup` to a function in module scope which accepts an
instance as its public argument, and use that when calling
`registerDestructor` as well as at the start of every `modify` call.
This results in having exactly one function allocated for the
destructor to call, instead of a function per instance. This is a
relatively small win, but a meaningful one which might add up
significantly if you have many of these on a given page.

