### PR TITLE
when item is disabled, do not add event listeners

### DIFF
--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -849,7 +849,7 @@ export default class SortableItemModifier extends Modifier {
 
     if (this.named.disabled && this.listenersRegistered) {
       this.removeEventListener();
-    } else if (!this.args.named.disabled && !this.listenersRegistered) {
+    } else if (!this.named.disabled && !this.listenersRegistered) {
       this.addEventListener();
     }
   }

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -803,16 +803,24 @@ export default class SortableItemModifier extends Modifier {
     this.element.addEventListener('keydown', this.keyDown);
     this.element.addEventListener('mousedown', this.mouseDown);
     this.element.addEventListener('touchstart', this.touchStart);
+    this.listenersRegistered = true;
   }
 
   removeEventListener() {
     this.element.removeEventListener('keydown', this.keyDown);
     this.element.removeEventListener('mousedown', this.mouseDown);
     this.element.removeEventListener('touchstart', this.touchStart);
+    this.listenersRegistered = false;
   }
 
   element;
   didSetup = false;
+
+
+  /**
+   * tracks if event listeners have been registered. Registering event handlers is unnecessary if item is disabled.
+   */
+  listenersRegistered = false;
 
   constructor(owner, args) {
     super(owner, args);
@@ -835,10 +843,15 @@ export default class SortableItemModifier extends Modifier {
     }
 
     if (!this.didSetup) {
-      this.addEventListener();
       this.element.dataset.sortableItem = true;
       this.sortableService.registerItem(this.groupName, this);
       this.didSetup = true;
+    }
+
+    if (this.args.named.disabled && this.listenersRegistered) {
+      this.removeEventListener();
+    } else if (!this.args.named.disabled && !this.listenersRegistered) {
+      this.addEventListener();
     }
   }
 }

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -847,7 +847,7 @@ export default class SortableItemModifier extends Modifier {
       this.didSetup = true;
     }
 
-    if (this.args.named.disabled && this.listenersRegistered) {
+    if (this.named.disabled && this.listenersRegistered) {
       this.removeEventListener();
     } else if (!this.args.named.disabled && !this.listenersRegistered) {
       this.addEventListener();

--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -816,7 +816,6 @@ export default class SortableItemModifier extends Modifier {
   element;
   didSetup = false;
 
-
   /**
    * tracks if event listeners have been registered. Registering event handlers is unnecessary if item is disabled.
    */


### PR DESCRIPTION
This PR makes sure event listeners on sortable-item are only added when the item is not disabled, as it appears to be a waste of resources to add event listeners to an element where they are not needed. Sortable group already does not register listeners when in disabled state. 

Background: In a template, I do not want to maintain a list for display purposes and a separate list for editing. Therefore I would like to have a list that where I can enable editing, that does not consume unnecessary resources in display state.

This PR makes #353 obsolete.