### PR TITLE
fix: Handle element in sortable item should be the most recent

### DIFF
--- a/addon/modifiers/sortable-item.js
+++ b/addon/modifiers/sortable-item.js
@@ -268,6 +268,8 @@ export default class SortableItemModifier extends Modifier {
       return;
     }
 
+    this.setupHandleElement();
+
     // If the event is coming from within the item, we do not want to activate keyboard reorder mode.
     if (event.target === this.handleElement || event.target === this.element) {
       this.sortableGroup.activateKeyDown(this);
@@ -811,6 +813,16 @@ export default class SortableItemModifier extends Modifier {
     this.element.removeEventListener('touchstart', this.touchStart);
   }
 
+  setupHandleElement() {
+    this.handleElement = this.element.querySelector(this.handle);
+
+    if (this.handleElement) {
+      this.handleElement.style['touch-action'] = 'none';
+    } else {
+      this.element.style['touch-action'] = 'none';
+    }
+  }
+
   element;
   didSetup = false;
 
@@ -827,13 +839,7 @@ export default class SortableItemModifier extends Modifier {
 
     // Instead of using `event.preventDefault()` in the 'primeDrag' event,
     // (doesn't work in Chrome 56), we set touch-action: none as a workaround.
-    this.handleElement = this.element.querySelector(this.handle);
-
-    if (this.handleElement) {
-      this.handleElement.style['touch-action'] = 'none';
-    } else {
-      this.element.style['touch-action'] = 'none';
-    }
+    this.setupHandleElement();
 
     if (!this.didSetup) {
       this.addEventListener();

--- a/tests/acceptance/smoke-modifier-test.js
+++ b/tests/acceptance/smoke-modifier-test.js
@@ -433,6 +433,51 @@ module('Acceptance | smoke modifier', function (hooks) {
       await triggerKeyEvent('[data-test-vertical-demo-group]', 'keydown', ENTER_KEY_CODE);
 
       assert.equal(justDraggedContents(), 'Zero');
+
+      assert.equal(tableConditionalCellContents(), 'avocado banana cashew watermelon durian apple lemon ');
+      await focus('[data-test-table-conditional-cell-handle]');
+
+      await triggerKeyEvent('[data-test-table-conditional-cell-handle]', 'keydown', ENTER_KEY_CODE);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ARROW_KEY_CODES.DOWN);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ENTER_KEY_CODE);
+
+      assert.equal(tableConditionalCellContents(), 'banana avocado cashew watermelon durian apple lemon ');
+    });
+
+    test('Keyboard selection works multiple times for conditionally rendered sort-handle', async function (assert) {
+      await visit('/');
+
+      assert.equal(tableConditionalCellContents(), 'avocado banana cashew watermelon durian apple lemon ');
+
+      await focus('[data-test-table-conditional-cell-handle]');
+
+      await triggerKeyEvent('[data-test-table-conditional-cell-handle]', 'keydown', ENTER_KEY_CODE);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ARROW_KEY_CODES.DOWN);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ENTER_KEY_CODE);
+
+      assert.equal(tableConditionalCellContents(), 'banana avocado cashew watermelon durian apple lemon ');
+
+      const moveHandle = findAll('[data-test-table-conditional-cell-handle]')[4];
+      await focus(moveHandle);
+
+      await triggerKeyEvent(moveHandle, 'keydown', ENTER_KEY_CODE);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ARROW_KEY_CODES.UP);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ARROW_KEY_CODES.UP);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ENTER_KEY_CODE);
+
+      assert.equal(tableConditionalCellContents(), 'banana avocado durian cashew watermelon apple lemon ');
+
+      const moveHandle1 = findAll('[data-test-table-conditional-cell-handle]')[0];
+      await focus(moveHandle1);
+
+      await triggerKeyEvent(moveHandle1, 'keydown', ENTER_KEY_CODE);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ARROW_KEY_CODES.DOWN);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ARROW_KEY_CODES.DOWN);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ARROW_KEY_CODES.DOWN);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ARROW_KEY_CODES.DOWN);
+      await triggerKeyEvent('[data-test-table-conditional-cell-demo-group]', 'keydown', ENTER_KEY_CODE);
+
+      assert.equal(tableConditionalCellContents(), 'avocado durian cashew watermelon banana apple lemon ');
     });
   });
 
@@ -458,5 +503,16 @@ module('Acceptance | smoke modifier', function (hooks) {
 
   function contents(selector) {
     return find(selector).textContent.replace(/⇕/g, '').replace(/\s+/g, ' ').replace(/^\s+/, '').replace(/\s+$/, '');
+  }
+
+  function tableConditionalCellContents() {
+    const elements = findAll('[data-test-fruits]');
+    let result = '';
+    for (const index in elements) {
+      const element = elements[index];
+      result += element.textContent.replace(/⇕/g, '').replace(/\s+/g, ' ').replace(/^\s+/, '').replace(/\s+$/, '');
+      result += ' ';
+    }
+    return result;
   }
 });

--- a/tests/dummy/app/components/cells/day-of-week/index.hbs
+++ b/tests/dummy/app/components/cells/day-of-week/index.hbs
@@ -1,0 +1,1 @@
+<td>{{@record.day}}</td>

--- a/tests/dummy/app/components/cells/fruit/index.hbs
+++ b/tests/dummy/app/components/cells/fruit/index.hbs
@@ -1,0 +1,1 @@
+<td data-test-fruits>{{@record.fruit}}</td>

--- a/tests/dummy/app/components/cells/sortable/index.hbs
+++ b/tests/dummy/app/components/cells/sortable/index.hbs
@@ -1,0 +1,1 @@
+<td data-test-table-conditional-cell-handle {{sortable-handle index=@index}} ...attributes>{{@index}}</td>

--- a/tests/dummy/app/components/row/component.js
+++ b/tests/dummy/app/components/row/component.js
@@ -1,40 +1,6 @@
 import Component from '@glimmer/component';
-import { setComponentTemplate } from '@ember/component';
-import templateOnly from '@ember/component/template-only';
-import { hbs } from 'ember-cli-htmlbars';
-
-const SortableCell = templateOnly();
-
-setComponentTemplate(
-  hbs`{{log 'rendering cell' @index}}
-    <td data-test-table-conditional-cell-handle {{sortable-handle index=@index}} ...attributes>{{@index}}</td>
-  `,
-  SortableCell
-);
-
-const FruitCell = templateOnly();
-
-setComponentTemplate(
-  hbs`
-  <td data-test-fruits>{{@record.fruit}}</td>
-  `,
-  FruitCell
-);
-
-const DayOfWeekCell = templateOnly();
-
-setComponentTemplate(
-  hbs`
-  <td>{{@record.day}}</td>
-  `,
-  DayOfWeekCell
-);
 
 export default class Row extends Component {
-  SortableCell = SortableCell;
-  FruitCell = FruitCell;
-  DayOfWeekCell = DayOfWeekCell;
-
   get isEven() {
     return this.args.index % 2 === 0;
   }

--- a/tests/dummy/app/components/row/component.js
+++ b/tests/dummy/app/components/row/component.js
@@ -1,0 +1,41 @@
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import templateOnly from '@ember/component/template-only';
+import { hbs } from 'ember-cli-htmlbars';
+
+const SortableCell = templateOnly();
+
+setComponentTemplate(
+  hbs`{{log 'rendering cell' @index}}
+    <td data-test-table-conditional-cell-handle {{sortable-handle index=@index}} ...attributes>{{@index}}</td>
+  `,
+  SortableCell
+);
+
+const FruitCell = templateOnly();
+
+setComponentTemplate(
+  hbs`
+  <td data-test-fruits>{{@record.fruit}}</td>
+  `,
+  FruitCell
+);
+
+const DayOfWeekCell = templateOnly();
+
+setComponentTemplate(
+  hbs`
+  <td>{{@record.day}}</td>
+  `,
+  DayOfWeekCell
+);
+
+export default class Row extends Component {
+  SortableCell = SortableCell;
+  FruitCell = FruitCell;
+  DayOfWeekCell = DayOfWeekCell;
+
+  get isEven() {
+    return this.args.index % 2 === 0;
+  }
+}

--- a/tests/dummy/app/components/row/template.hbs
+++ b/tests/dummy/app/components/row/template.hbs
@@ -1,0 +1,9 @@
+<tr ...attributes>
+  {{#if this.isEven}}
+    <this.SortableCell @index={{@index}} />
+  {{else}}
+    <this.SortableCell @index={{@index}} class="odd-class"/>
+  {{/if}}
+  <this.FruitCell @record={{@record}} />
+  <this.DayOfWeekCell @record={{@record}}/>
+</tr>

--- a/tests/dummy/app/components/row/template.hbs
+++ b/tests/dummy/app/components/row/template.hbs
@@ -1,9 +1,9 @@
 <tr ...attributes>
   {{#if this.isEven}}
-    <this.SortableCell @index={{@index}} />
+    <Cells::Sortable @index={{@index}} />
   {{else}}
-    <this.SortableCell @index={{@index}} class="odd-class"/>
+    <Cells::Sortable @index={{@index}} class="odd-class"/>
   {{/if}}
-  <this.FruitCell @record={{@record}} />
-  <this.DayOfWeekCell @record={{@record}}/>
+  <Cells::Fruit @record={{@record}} />
+  <Cells::DayOfWeek @record={{@record}}/>
 </tr>

--- a/tests/dummy/app/components/table/template.hbs
+++ b/tests/dummy/app/components/table/template.hbs
@@ -1,0 +1,11 @@
+<table data-test-table-conditional-cell-demo-group {{sortable-group onChange=@handleDragChange groupName="table-tracked" }} >
+  <thead> 
+    <td>Order</td>
+    <td>Fruit</td>
+    <td>Day of Week</td> </thead>
+  <tbody>
+    {{#each @records as |record index|}}
+      <Row @record={{record}} @index={{index}} {{sortable-item model=record groupName="table-tracked"}}  />
+    {{/each}}
+  </tbody>
+</table>

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,8 +1,23 @@
 import Controller from '@ember/controller';
 import { set, action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class ModifierController extends Controller {
   differentSizedModels = ['A', 'B'.repeat(100), 'D'.repeat(50), 'C'.repeat(20)];
+
+  @tracked records = [
+    { fruit: 'avocado', day: 'Monday' },
+    { fruit: 'banana', day: 'Tuesday' },
+    { fruit: 'cashew', day: 'Wednesday' },
+    { fruit: 'watermelon', day: 'Thursday' },
+    { fruit: 'durian', day: 'Friday' },
+    { fruit: 'apple', day: 'Saturday' },
+    { fruit: 'lemon', day: 'Sunday' },
+  ];
+
+  @action handleDragChange(reordered) {
+    this.records = reordered;
+  }
 
   handleVisualClass = {
     UP: 'sortable-handle-up',
@@ -43,6 +58,7 @@ export default class ModifierController extends Controller {
   updateDifferentSizedModels(newOrder) {
     set(this, 'differentSizedModels', newOrder);
   }
+
   @action
   update(newOrder, draggedModel) {
     set(this, 'model.items', newOrder);

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -90,6 +90,11 @@
       </table>
     </section>
 
+    <section class="table-cell-changes-demo">
+      <h3>Table with conditional cells</h3>
+      <Table @records={{this.records}} @handleDragChange={{this.handleDragChange}} />
+    </section>
+
     <section class='vertical-spacing-demo'>
       <h3>Vertical with 15px spacing</h3>
 


### PR DESCRIPTION
Related issue: https://github.com/adopted-ember-addons/ember-sortable/issues/492

## What changed
- [x] added a demo to the demos page
- [x] this demo has a conditionally rendered sort handle

```hbs
  {{#if this.isEven}}
    <Cells::Sortable @index={{@index}} />
  {{else}}
    <Cells::Sortable @index={{@index}} class="odd-class"/>
  {{/if}}
```
- [x] because of this, the `{{sort-handle}}` is rendered more often than the `{{sortable-item}}`. Because of this, the `this.handleElement` in `{{sort-item}}` is one that is no longer in the document body.
- [x] adding in a way to get the new `this.handleElement` in the `keyDown` handler fixes this issue
- [x] updated tests

## How to test
(refer to the animation in the issue)
1. start the demo with `ember serve`
2. Using your mouse (it's faster) click on the demo I created
3. Use TAB to select a fruit
4. Use ENTER to go into drag mode
5. Use ARROW KEYS to move
6. Use ENTER/SPACE to commit
7. Repeat steps 1-6 more than 3 times. It should work every time.

`ember test` should also pass.
