### PR TITLE
Move test config to the dummy app

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,26 +1,5 @@
 'use strict';
 
-module.exports = function (environment) {
-  const ENV = {
-    environment,
-
-    'ember-a11y-testing': {
-      componentOptions: {
-        turnAuditOff: true,
-        excludeAxeCore: true,
-        axeOptions: {
-          iframes: false,
-          reporter: 'v2',
-          resultTypes: ['violations'],
-          rules: {
-            'duplicate-id': { enabled: false },
-            'duplicate-id-active': { enabled: false },
-            'duplicate-id-aria': { enabled: false },
-          },
-        },
-      },
-    },
-  };
-
-  return ENV;
+module.exports = function (/* environment, appConfig */) {
+  return {};
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -21,6 +21,23 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
+
+    'ember-a11y-testing': {
+      componentOptions: {
+        turnAuditOff: true,
+        excludeAxeCore: true,
+        axeOptions: {
+          iframes: false,
+          reporter: 'v2',
+          resultTypes: ['violations'],
+          rules: {
+            'duplicate-id': { enabled: false },
+            'duplicate-id-active': { enabled: false },
+            'duplicate-id-aria': { enabled: false },
+          },
+        },
+      },
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
This moves the `ember-a11y-testing` config into the dummy app's environment file. This prevents the config from being merged with the consuming app's config while it is only needed for the addon tests.