### PR TITLE
Move common dependencies to peer dependencies (ember-modifier, @ember/test-helpers, @ember/test-waiters)

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -32,11 +32,13 @@
     "start": "rollup --config --watch",
     "test": "echo 'Addon does not have tests, run tests in test-app'"
   },
+  "peerDependencies": {
+    "ember-modifier": "^3.2.0 || ^4.0.0",
+    "@ember/test-helpers": "^2.6.0",
+    "@ember/test-waiters": "^3.0.1"
+  },
   "dependencies": {
-    "@ember/test-waiters": "^3.0.1",
-    "@embroider/addon-shim": "^1.8.4",
-    "ember-modifier": "^3.2.0",
-    "@ember/test-helpers": "^2.6.0"
+    "@embroider/addon-shim": "^1.8.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
These dependencies are common enough that we'll want to defer to the consuming app's version of them to improve compatibility.


Tests are failing because yarn can't handle peer dependencies.
Guess this repo is switching to pnpm now.

Gonna merge the red PR, because too many things need to change for v5 prep, and release-it requires single-change, single-PR type workflow