### PR TITLE
importing from the _app_ directory was disallowed because of the exports config.

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -15,6 +15,7 @@
   },
   "exports": {
     ".": "./dist/index.js",
+    "./_app_/*": "./dist/_app_/*.js",
     "./modifiers/*": "./dist/modifiers/*",
     "./services/*": "./dist/services/*",
     "./test-support": "./dist/test-support/index.js",


### PR DESCRIPTION
Looks like none of the `_app_` files are importable.

this is an issue I thought we would have encountered sooner:
```
You tried to reverse exports for the file
   `./dist/_app_/modifiers/sortable-group.js` 
   in package `ember-sortable` but it does not match any 
   of the exports rules defined in package.json. 
   This means it should not be possible to access directly.
```
ember-sortable _is_ a v2 addon already, but forgot to re-export their `_app_` directory:
```
  "exports": {
    ".": "./dist/index.js",
    "./modifiers/*": "./dist/modifiers/*",
    "./services/*": "./dist/services/*",
    "./test-support": "./dist/test-support/index.js",
    "./addon-main.js": "./addon-main.js"
  },
```
:sweat_smile:


Discussion: https://discord.com/channels/480462759797063690/1182017862651629601/1182019040785473566 

--------------_

Note, by default, this sort of change isn't needed, as the blueprint includes _app_ already:
```
".": "./dist/index.js",
"./*": "./dist/*.js",
"./test-support": "./dist/test-support/index.js",
"./addon-main.js": "./addon-main.cjs"
```