### PR TITLE
Add missing extensions to exports

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -16,8 +16,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./_app_/*": "./dist/_app_/*.js",
-    "./modifiers/*": "./dist/modifiers/*",
-    "./services/*": "./dist/services/*",
+    "./modifiers/*": "./dist/modifiers/*.js",
+    "./services/*": "./dist/services/*.js",
     "./test-support": "./dist/test-support/index.js",
     "./addon-main.js": "./addon-main.js"
   },


### PR DESCRIPTION
This should fix the addon for use with the new experimental Embroider Vite build, thanks for the pointer @NullVoxPopuli!