### PR TITLE
Fix: Block drag start while any item is busy & add wait for transition end in test helper `drop`

### DIFF
--- a/addon/src/test-support/helpers/drag.js
+++ b/addon/src/test-support/helpers/drag.js
@@ -1,4 +1,4 @@
-import { triggerEvent, find, settled } from '@ember/test-helpers';
+import { triggerEvent, find, settled, waitUntil } from '@ember/test-helpers';
 import { getOffset } from '../utils/offset';
 
 /**
@@ -108,4 +108,11 @@ export async function drag(mode, itemSelector, offsetFn, callbacks = {}) {
     await callbacks.dragend();
     await settled();
   }
+
+  await waitUntil(
+    () => {
+      return !find('.is-dropping');
+    },
+    { timeout: 2000 }
+  );
 }


### PR DESCRIPTION
While added direction `grid` in PR #560 we have discovered, that the waiting for `transitionEnd` was not correctly. This has some side-effects in tests, when using with a bigger list of item, because the animation spents more time.

This was the reason, why added tests for direction `grid` were failed.

This PR fix following bugs
1. dropend and was already called before all transitions of all items was completed
2. after dropping a item and taking an other one immediately, brings crazy transition effect and sometime also order was not anymore correct
3. in tests the `drop` helper hasn't respected `transitionEnd`, caused by the other two bugs. Fast reordering like in tests are not working with large lists