### PR TITLE
fix(ts): make onChange argument optional

### DIFF
--- a/addon/src/modifiers/sortable-group.ts
+++ b/addon/src/modifiers/sortable-group.ts
@@ -49,7 +49,7 @@ interface SortableGroupModifierSignature<T> {
       a11yAnnouncementConfig?: A11yAnnouncementConfig;
       itemVisualClass?: string;
       a11yItemName?: string;
-      onChange: (itemModels: T[], draggedModel: T | undefined) => void;
+      onChange?: (itemModels: T[], draggedModel: T | undefined) => void;
     };
     Positional: unknown[];
   };


### PR DESCRIPTION
In the `addon/src/modifiers/sortable-group.ts` file, the `onChange` argument is marked as required. However, looking at the implementation, it looks like it should be optional instead.