### PR TITLE
Add missing declaration export for modifier, services & test-support

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -23,9 +23,18 @@
       "default": "./dist/*.js"
     },
     "./_app_/*": "./dist/_app_/*.js",
-    "./modifiers/*": "./dist/modifiers/*.js",
-    "./services/*": "./dist/services/*.js",
-    "./test-support": "./dist/test-support/index.js",
+    "./modifiers/*": {
+      "types": "./declarations/modifiers/*.d.ts",
+      "default": "./dist/modifiers/*.js"
+    },
+    "./services/*": {
+      "types": "./declarations/services/*.d.ts",
+      "default": "./dist/services/*.js"
+    },
+    "./test-support": {
+      "types": "./declarations/test-support/index.js",
+      "default": "./dist/test-support/index.js"
+    },
     "./addon-main.js": "./addon-main.cjs"
   },
   "typesVersions": {

--- a/addon/package.json
+++ b/addon/package.json
@@ -32,7 +32,7 @@
       "default": "./dist/services/*.js"
     },
     "./test-support": {
-      "types": "./declarations/test-support/index.js",
+      "types": "./declarations/test-support/index.d.ts",
       "default": "./dist/test-support/index.js"
     },
     "./addon-main.js": "./addon-main.cjs"


### PR DESCRIPTION
Like reported in discord typings are not working because declaration export is missing

![grafik](https://github.com/user-attachments/assets/acdc2ed0-7005-48e6-883b-79b17b786eca)


https://discord.com/channels/480462759797063690/491905849405472769/1288552863890407588