### PR TITLE
fix types for reorder and drag test helpers, fixes #586

### DIFF
--- a/addon/src/test-support/helpers/drag.ts
+++ b/addon/src/test-support/helpers/drag.ts
@@ -37,7 +37,7 @@ interface Callbacks {
 
 export async function drag(
   mode: TMode,
-  itemSelector: string,
+  itemSelector: keyof (HTMLElementTagNameMap | SVGElementTagNameMap) | string, // or Parameters<typeof find>[0][]
   offsetFn: () => { dx: number; dy: number },
   callbacks: Callbacks = {},
 ) {

--- a/addon/src/test-support/helpers/reorder.ts
+++ b/addon/src/test-support/helpers/reorder.ts
@@ -26,10 +26,10 @@ const OVERSHOOT = 2;
     selectors for the resultant order
   @return {Promise}
 */
-export async function reorder<T extends keyof HTMLElementTagNameMap>(
+export async function reorder(
   mode: TMode,
-  itemSelector: string,
-  ...resultSelectors: T[]
+  itemSelector: keyof (HTMLElementTagNameMap | SVGElementTagNameMap) | string, // or Parameters<typeof findAll>[0],
+  ...resultSelectors: (keyof (HTMLElementTagNameMap | SVGElementTagNameMap) | string)[] // or Parameters<typeof find>[0][]
 ) {
   for (let targetIndex = 0; targetIndex < resultSelectors.length; targetIndex++) {
     const items = findAll(itemSelector);


### PR DESCRIPTION
We can use Parameters<typeof find>[0] because we are passing the selectors to the find function.
```ts
  itemSelector: Parameters<typeof findAll>[0],
  ...resultSelectors: Parameters<typeof find>[0][]
```

or we can just copy their types
```ts
  itemSelector: keyof (HTMLElementTagNameMap | SVGElementTagNameMap) | string,
  ...resultSelectors: (keyof (HTMLElementTagNameMap | SVGElementTagNameMap) | string)[]
```

What's the best / cleanest / preferred method of doing this?