### PR TITLE
Cleanup `@ember/service` deprecation

### DIFF
--- a/addon/src/modifiers/sortable-group.ts
+++ b/addon/src/modifiers/sortable-group.ts
@@ -14,7 +14,7 @@ import {
 import { ANNOUNCEMENT_ACTION_TYPES } from '../utils/constant.ts';
 import { defaultA11yAnnouncementConfig, type A11yAnnouncementConfig } from '../utils/defaults.ts';
 import { next, schedule, scheduleOnce, later } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 import { registerDestructor, isDestroyed } from '@ember/destroyable';
 import type { ArgsFor, PositionalArgs, NamedArgs } from 'ember-modifier';
 import type Owner from '@ember/owner';
@@ -22,6 +22,8 @@ import type EmberSortableService from '../services/ember-sortable-internal-state
 import type { Group } from '../services/ember-sortable-internal-state.ts';
 import type SortableItemModifier from './sortable-item.ts';
 import type { MoveDirection } from './sortable-item.ts';
+
+const service = s.service ?? s.inject;
 
 const NO_MODEL: HandleVisualClass = {};
 

--- a/addon/src/modifiers/sortable-item.ts
+++ b/addon/src/modifiers/sortable-item.ts
@@ -10,7 +10,7 @@ import ScrollContainer from '../system/scroll-container.ts';
 import scrollParent from '../system/scroll-parent.ts';
 import { getBorderSpacing } from '../utils/css-calculation.ts';
 import { buildWaiter } from '@ember/test-waiters';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 import { assert, deprecate } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
 import { isTesting } from '@embroider/macros';
@@ -20,6 +20,8 @@ import type Owner from '@ember/owner';
 import type { Group } from '../services/ember-sortable-internal-state.ts';
 import type SortableGroupModifier from './sortable-group.ts';
 import type { TDirection } from './sortable-group.ts';
+
+const service = s.service ?? s.inject;
 
 const sortableItemWaiter = buildWaiter('sortable-item-waiter');
 


### PR DESCRIPTION
In ember v6.3 there was added deprecation for service import from inject https://deprecations.emberjs.com/id/importing-inject-from-ember-service/

This changes allows us to hold support for `ember-source` <= 4.0 ([see changelog](https://github.com/emberjs/ember.js/blob/main/CHANGELOG.md#v410-december-28-2021)) and removes deprecation in newer versions