### PR TITLE
Remove unneeded peer dependency on ember-source

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -69,8 +69,7 @@
   "peerDependencies": {
     "ember-modifier": "^3.2.0 || >= 4.0.0",
     "@ember/test-helpers": "^2.6.0 || >= 3.0.0",
-    "@ember/test-waiters": ">= 3.0.1",
-    "ember-source": "^3.28.0 || >= 4.0.0"
+    "@ember/test-waiters": ">= 3.0.1"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.9",


### PR DESCRIPTION
- ember-source: removed because the embroider / auto-import know what we intend - it's not bad to have if someone manages their dep graph correctly, which is easier with pnpm, but not everyone gets it right, and folks have a hard time tracking down errors
- @glimmer/tracking removed because it's a real package, but one we don't want to use. This comes up in embroider/vite where the presence of real packages always takes precedence over virtual packages. This is actually problematic because it can break reactivity in subtle ways, even if a dep graph is correct - allowing duplicates of dependencies, which for the glimmer internals, we don't want.

ref https://github.com/ember-cli/ember-addon-blueprint/pull/35