### PR TITLE
`transitionend` will not fired, when transition has a short duration

### DIFF
--- a/addon/src/modifiers/sortable-item.ts
+++ b/addon/src/modifiers/sortable-item.ts
@@ -861,7 +861,7 @@ export default class SortableItemModifier<T> extends Modifier<SortableItemModifi
       const animations = this.sortableGroup.sortedItems.map((x) => x.element.getAnimations());
 
       const animationPromises = animations.flatMap((animationList) => {
-        return animationList.map(animation => animation.finished);
+        return animationList.map((animation) => animation.finished);
       });
 
       transitionPromise = Promise.all(animationPromises);


### PR DESCRIPTION
### Issue / Fix
In our app we have the issue, that an dragged item stays in `isDropping` status.
After debugging i have discovered that the the promise of `this._waitForTransition` is endless in pending state. The result is the dragging ends in `Promise.all([transitionPromise, allTransitionPromise]).then(() => this._complete());`

https://github.com/adopted-ember-addons/ember-sortable/blob/325228b1a4ecec41e2153f42520cec0fc7acf55a/addon/src/modifiers/sortable-item.ts#L755-L777

This bug occures not always, but is often and is reproducible in any places in our app... its more a timeing bug, when the transition duration has a short time (in our case the issue comes already with 125ms). In test app there was not possible to reproduce (maybe because the page is smaller, is not so a nested HTML, JS/CSS is smaller like in an production app...)

My initial idea was to fix this issue with `Element.getAnimations()`, but it wasn't possible... it looks like the animation is already finished, before the `_drop` function will be called...

The only fix (which should be always safe), is to add an `later` which will be called always after `transitionDuration` + additional short delay (implemented right now with 200ms)

### Alternative?
An alternative could be to add the `transitionend` in modifier constructor and keep it active for life-time, but i'm not sure in which issues we run after this change (in this case we need some local variable to hold states/promise...)