### PR TITLE
Fix getBorderSpacing util function for chrome 138.0.7204.169

### DIFF
--- a/addon/utils/css-calculation.js
+++ b/addon/utils/css-calculation.js
@@ -7,7 +7,7 @@
   @private
 */
 export function getBorderSpacing(el) {
-  let css = getComputedStyle(el).borderSpacing; // '0px 0px'
+  let css = getComputedStyle(el).borderSpacing; // '0px 0px' or '0px'
   let [horizontal, vertical = 0] = css.split(' ');
 
   return {


### PR DESCRIPTION
🐛 Bug Fix: Reordering issue in Chrome v138.0.7204.169

This PR fixes a bug where reordering functionality fails in Chrome version 138.0.7204.169 and above.

📝 Details

Starting with Chrome v138.0.7204.169, the getComputedStyle(el).borderSpacing property now returns a shorthand value (e.g., "0px") instead of separate horizontal and vertical values. This change causes the reordering logic to fail, as it was previously expecting a specific vertical spacing value.

🛠️ Solution

To fix this, a default value has been added for the vertical spacing when the getComputedStyle property returns a shorthand value. This ensures the reordering logic can correctly calculate the element positions, restoring the functionality in the affected Chrome versions.

