### PR TITLE
fix: don't abort drop when a drop animation is cancelled (#641)

### DIFF
--- a/addon/src/modifiers/sortable-item.ts
+++ b/addon/src/modifiers/sortable-item.ts
@@ -868,7 +868,19 @@ export default class SortableItemModifier<T> extends Modifier<SortableItemModifi
       const animations = this.sortableGroup.sortedItems.map((x) => x.element.getAnimations());
 
       const animationPromises = animations.flatMap((animationList) => {
-        return animationList.map((animation) => animation.finished);
+        return animationList.map((animation) =>
+          // A cancelled animation (e.g. one interrupted by the re-render that
+          // happens mid-drop) rejects `finished` with an AbortError. Treat it
+          // as finished so the drop still completes, instead of leaving this
+          // promise chain unhandled and blocking all subsequent drag/drop.
+          // Re-throw anything else. See #641.
+          animation.finished.catch((error: unknown) => {
+            if (error instanceof DOMException && error.name === 'AbortError') {
+              return;
+            }
+            throw error;
+          }),
+        );
       });
 
       transitionPromise = Promise.all(animationPromises);

--- a/test-app/tests/integration/modifiers/sortable-item-test.js
+++ b/test-app/tests/integration/modifiers/sortable-item-test.js
@@ -8,6 +8,61 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Modifier | sortable-item', function (hooks) {
   setupRenderingTest(hooks);
 
+  // #641: on drop, `_waitForAllTransitions` awaits each item's Web Animations
+  // `finished` promise. If an animation gets cancelled mid-drop, say by the
+  // re-render from `sortableGroup.update`, the browser rejects `finished` with
+  // a DOMException named 'AbortError'. We swallow that one so the drop still
+  // completes. Any other rejection has to keep propagating, otherwise a real
+  // failure gets hidden.
+  test('A cancelled animation is treated as finished, other rejections propagate', async function (assert) {
+    this.items = ['Uno', 'Dos', 'Tres'];
+    this.update = (items) => set(this, 'items', items);
+
+    await render(hbs`
+      <ol id="test-list" {{sortable-group groupName="ohai" onChange=this.update}}>
+        {{#each this.items as |item|}}
+          <li data-test-item {{sortable-item groupName="ohai" model=item}}>{{item}}</li>
+        {{/each}}
+      </ol>
+    `);
+
+    const group = this.owner
+      .lookup('service:ember-sortable-internal-state')
+      .fetchGroup('ohai');
+    const item = group.items[0];
+
+    // The getAnimations() path we're testing only runs when `isAnimated` is
+    // true, which needs a real transition on the element. Give every item one
+    // and assert it took, so the test can't pass down the timeout branch.
+    item.sortableGroup.sortedItems.forEach((sortedItem) => {
+      sortedItem.element.style.transition = 'transform 100ms';
+    });
+    assert.true(item.isAnimated, 'the item is animated, so the getAnimations() path runs');
+
+    const stubAnimations = (finished) => {
+      item.sortableGroup.sortedItems.forEach((sortedItem) => {
+        sortedItem.element.getAnimations = () => [{ finished }];
+      });
+    };
+
+    stubAnimations(Promise.reject(new DOMException('The user aborted a request', 'AbortError')));
+
+    try {
+      await item._waitForAllTransitions();
+      assert.ok(true, 'the drop resolves instead of rejecting on a cancelled animation');
+    } catch {
+      assert.ok(false, 'the drop should not reject when an animation is cancelled');
+    }
+
+    stubAnimations(Promise.reject(new Error('boom')));
+
+    await assert.rejects(
+      item._waitForAllTransitions(),
+      /boom/,
+      'genuine animation failures are not masked',
+    );
+  });
+
   test('Drag works with one item', async function (assert) {
     this.items = ['Uno'];
 

--- a/test-app/tests/integration/modifiers/sortable-item-test.js
+++ b/test-app/tests/integration/modifiers/sortable-item-test.js
@@ -37,7 +37,10 @@ module('Integration | Modifier | sortable-item', function (hooks) {
     item.sortableGroup.sortedItems.forEach((sortedItem) => {
       sortedItem.element.style.transition = 'transform 100ms';
     });
-    assert.true(item.isAnimated, 'the item is animated, so the getAnimations() path runs');
+    assert.true(
+      item.isAnimated,
+      'the item is animated, so the getAnimations() path runs',
+    );
 
     const stubAnimations = (finished) => {
       item.sortableGroup.sortedItems.forEach((sortedItem) => {
@@ -45,13 +48,23 @@ module('Integration | Modifier | sortable-item', function (hooks) {
       });
     };
 
-    stubAnimations(Promise.reject(new DOMException('The user aborted a request', 'AbortError')));
+    stubAnimations(
+      Promise.reject(
+        new DOMException('The user aborted a request', 'AbortError'),
+      ),
+    );
 
     try {
       await item._waitForAllTransitions();
-      assert.ok(true, 'the drop resolves instead of rejecting on a cancelled animation');
+      assert.ok(
+        true,
+        'the drop resolves instead of rejecting on a cancelled animation',
+      );
     } catch {
-      assert.ok(false, 'the drop should not reject when an animation is cancelled');
+      assert.ok(
+        false,
+        'the drop should not reject when an animation is cancelled',
+      );
     }
 
     stubAnimations(Promise.reject(new Error('boom')));


### PR DESCRIPTION
## What / Why

Fixes #641.

On drop, `_waitForAllTransitions` awaits each item's Web Animations `finished` promise:

```js
const animationPromises = animations.flatMap((animationList) => {
  return animationList.map((animation) => animation.finished);
});
transitionPromise = Promise.all(animationPromises);
```

When a transition is interrupted mid-drop — e.g. by the re-render triggered from `sortableGroup.update`, or a fast drag/drop before the animation finishes — the browser **cancels** the animation, and per the Web Animations spec `animation.finished` rejects with a `DOMException` named `AbortError` ("The user aborted a request").

`_drop` chains the result with `.then(() => this._complete())` and no rejection handler:

```js
Promise.all([transitionPromise, allTransitionPromise]).then(() => this._complete());
```

So the AbortError becomes an **uncaught promise rejection**, `_complete()` never runs, and `onDragStop` / the group's `onChange` never fires. The item keeps its `.is-dropping` class and **all subsequent drag/drop is broken**. Reproducible in Chrome, Firefox and Safari (matches the reports in #641).

## Fix

Treat a cancelled animation as finished (a cancelled animation rejecting `finished` is expected per spec), so the drop still commits. Any other rejection is re-thrown so genuine failures aren't masked:

```js
animation.finished.catch((error: unknown) => {
  if (error instanceof DOMException && error.name === 'AbortError') {
    return;
  }
  throw error;
})
```

## Testing

Manually verified against the reproduction in #641: with the fix, interrupting a drop no longer throws, the reorder commits, and subsequent drags keep working. Happy to add an automated test if maintainers can point me at the best way to simulate a cancelled `getAnimations()` transition in the test app.
