### PR TITLE
fix: use subpixel rect widths in grid-direction position math

### DIFF
--- a/addon/src/modifiers/sortable-group.ts
+++ b/addon/src/modifiers/sortable-group.ts
@@ -25,6 +25,10 @@ import type { MoveDirection } from './sortable-item.ts';
 
 const service = s.service ?? s.inject;
 
+// Tolerance for the grid direction's wrap check, absorbing residual
+// subpixel float error so a row that truly fits doesn't wrap on noise.
+const GRID_WRAP_EPSILON = 1;
+
 const NO_MODEL: HandleVisualClass = {};
 
 export interface HandleVisualClass {
@@ -759,7 +763,7 @@ export default class SortableGroupModifier<T> extends Modifier<SortableGroupModi
     }
 
     sortedItems.forEach((item) => {
-      if (direction === 'grid' && position + item.width > groupPositionRight) {
+      if (direction === 'grid' && position + item.width > groupPositionRight + GRID_WRAP_EPSILON) {
         lastTopOffset = lastTopOffset + maxPrevHeight;
         position = axis.x;
         maxPrevHeight = 0;

--- a/addon/src/modifiers/sortable-group.ts
+++ b/addon/src/modifiers/sortable-group.ts
@@ -749,8 +749,11 @@ export default class SortableGroupModifier<T> extends Modifier<SortableGroupModi
     if (direction === 'grid') {
       position = axis.x;
       lastTopOffset = axis.y;
-      const groupStyles = getComputedStyle(this.element);
-      groupPositionRight = position + parseFloat(groupStyles.width);
+
+      // `getBoundingClientRect` instead of `getComputedStyle(...).width`,
+      // which serializes to only 3 decimal places and can itself introduce
+      // rounding drift against item widths.
+      groupPositionRight = position + this.element.getBoundingClientRect().width;
     } else {
       position = axis[direction];
     }

--- a/addon/src/modifiers/sortable-item.ts
+++ b/addon/src/modifiers/sortable-item.ts
@@ -980,10 +980,13 @@ export default class SortableItemModifier<T> extends Modifier<SortableItemModifi
    */
   get width(): number {
     const el = this.element;
-    let width = el.offsetWidth;
+
+    // `offsetWidth` rounds to the nearest integer; summing rounded widths
+    // across items can drift enough to break the grid direction's wrap check.
+    let width = el.getBoundingClientRect().width;
     const elStyles = getComputedStyle(el);
 
-    width += parseInt(elStyles.marginLeft) + parseInt(elStyles.marginRight); // equal to jQuery.outerWidth(true)
+    width += parseFloat(elStyles.marginLeft) + parseFloat(elStyles.marginRight); // equal to jQuery.outerWidth(true)
 
     width += getBorderSpacing(el).horizontal;
 
@@ -997,7 +1000,9 @@ export default class SortableItemModifier<T> extends Modifier<SortableItemModifi
    */
   get height(): number {
     const el = this.element;
-    let height = el.offsetHeight;
+
+    // See `width` above for why this avoids the rounded `offsetHeight`.
+    let height = el.getBoundingClientRect().height;
     const elStyles = getComputedStyle(el);
 
     // This is needed atm only for grid, to fix jumping on drag-start.

--- a/test-app/app/styles/app.css
+++ b/test-app/app/styles/app.css
@@ -295,3 +295,19 @@
 .word-break {
   word-wrap: break-word;
 }
+
+/* Used by the grid-direction subpixel-rounding regression test. */
+.test-grid-tight-fit {
+  display: flex;
+  flex-wrap: wrap;
+  width: max-content;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.test-grid-tight-fit-item {
+  box-sizing: content-box;
+  width: 100.6px;
+  margin: 0;
+}

--- a/test-app/tests/integration/modifiers/sortable-group-test.js
+++ b/test-app/tests/integration/modifiers/sortable-group-test.js
@@ -9,7 +9,7 @@ import {
   waitUntil,
 } from '@ember/test-helpers';
 import { set } from '@ember/object';
-import { reorder } from 'ember-sortable/test-support';
+import { drag, reorder } from 'ember-sortable/test-support';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Modifier | sortable-group', function (hooks) {
@@ -73,6 +73,44 @@ module('Integration | Modifier | sortable-group', function (hooks) {
 
     assert.ok(true, 'Reorder prevented');
     assert.verifySteps([]);
+  });
+
+  test('grid direction does not spuriously wrap the last item of a tightly-fit row while dragging', async function (assert) {
+    // Item widths (100.6px, see app.css) round up under `offsetWidth`, so summing
+    // them exceeds the container's real subpixel width even though everything fits.
+    this.items = ['Uno', 'Dos', 'Tres'];
+
+    this.update = (items) => {
+      set(this, 'items', items);
+    };
+
+    await render(hbs`
+      <ul
+        id="test-grid-list"
+        class="test-grid-tight-fit"
+        {{sortable-group direction="grid" onChange=this.update}}
+      >
+        {{#each this.items as |item|}}
+          <li class="test-grid-tight-fit-item" {{sortable-item model=item}}>{{item}}</li>
+        {{/each}}
+      </ul>
+    `);
+
+    const items = findAll('#test-grid-list li');
+    const lastItem = items[2];
+    const lastItemTopBeforeDrag = lastItem.getBoundingClientRect().top;
+
+    await drag('mouse', items[0], () => ({ dx: 0, dy: 0 }), {
+      beforedragend: async () => {
+        const lastItemTopDuringDrag = lastItem.getBoundingClientRect().top;
+
+        assert.equal(
+          lastItemTopDuringDrag,
+          lastItemTopBeforeDrag,
+          'the last item stays on the same row mid-drag instead of jumping to a phantom next row',
+        );
+      },
+    });
   });
 
   test('Announcer has appropriate text for user actions', async function (assert) {


### PR DESCRIPTION
## Summary

With `direction: 'grid'`, `SortableGroupModifier#update` decides whether an item wraps to a new row by comparing a running sum of item widths against the container's own width. That comparison mixes two different rounding sources:

- `SortableItemModifier#width`/`#height` read `offsetWidth`/`offsetHeight`, which round to the nearest integer pixel.
- The container's width comes from `getComputedStyle(...).width`, a CSSOM string serialized to only 3 decimal places (e.g. `"301.781px"` for a true `301.78125`).

With uniform, fixed-pixel-width items (like this repo's own grid demo) neither rounding source matters — every item is already an integer, and the demo's container is far wider than its content, nowhere near the wrap boundary. But with **variable-width items in a container sized tightly to its own content** (e.g. a flex-wrap row of differently-sized tags/badges, sized to exactly fit them with no slack), the accumulated rounding drift can push the comparison past the boundary a hair early — wrapping the **last item** into a row that doesn't exist in the real CSS layout. It's visible as a spurious jump the instant a drag starts, even with zero drag distance, since `update()` runs on the first drag tick regardless of whether any reordering is actually happening.

The same wrap check also runs continuously throughout a drag (not just once), including while live-previewing a reorder as the dragged item passes over its neighbors. Even after fixing the two rounding sources above, that repeated re-evaluation can still land the running sum and the container width within a hair of exact equality, where `>` flips on ordinary floating-point noise rather than a real overflow — reproduced live with variable-width tags mid-drag.

## Fix

- Switch both sides of the comparison to `getBoundingClientRect()`, which gives subpixel-precise floats for both the item and the container, instead of mixing rounded integers with a truncated CSSOM string.
- Add a small epsilon tolerance to the comparison itself, so residual float noise at an exact-equality boundary can't flip it.

## Test plan

- Added an integration test reproducing the bug with a `direction="grid"` list of items whose true width (`100.6px`) rounds up under `offsetWidth`, in a container sized via `width: max-content` to exactly fit them (zero slack) — matching the conditions under which this fires.
- Verified the new test fails on `master` (reverting only this PR's source changes) and passes with the fix.
- `pnpm test` in `test-app` — all tests pass except 4 pre-existing failures (`AbortError` in the `grid`/`grid demo 2` acceptance tests, both mouse and touch) that are already failing identically on unmodified `master`, unrelated to this change.
- `pnpm lint` clean in both `addon` and `test-app`.
- Manually verified in a downstream app with a real `direction="grid"` flex-wrap tag list (variable-width tags, tight-fit container): the wrap-on-drag-start is gone, and dragging a tag back and forth across its neighbors no longer shows the transient wrap-then-restore flash.