### PR TITLE
feat: support flex/grid gap between sortable items

### DIFF
--- a/addon/src/modifiers/sortable-group.ts
+++ b/addon/src/modifiers/sortable-group.ts
@@ -12,6 +12,7 @@ import {
   isUpArrowKey,
 } from '../utils/keyboard.ts';
 import { ANNOUNCEMENT_ACTION_TYPES } from '../utils/constant.ts';
+import { getGap } from '../utils/css-calculation.ts';
 import { defaultA11yAnnouncementConfig, type A11yAnnouncementConfig } from '../utils/defaults.ts';
 import { next, schedule, scheduleOnce, later } from '@ember/runloop';
 import * as s from '@ember/service';
@@ -740,6 +741,7 @@ export default class SortableGroupModifier<T> extends Modifier<SortableGroupModi
     }
 
     const direction = this.direction;
+    const gap = getGap(this.element);
 
     let position = 0;
     let groupPositionRight = 0;
@@ -778,16 +780,16 @@ export default class SortableGroupModifier<T> extends Modifier<SortableGroupModi
 
       if (direction === 'grid') {
         if (item.height > maxPrevHeight) {
-          maxPrevHeight = item.height;
+          maxPrevHeight = item.height + gap.vertical;
         }
 
-        position += item.width;
+        position += item.width + gap.horizontal;
       }
       if (direction === 'x') {
-        position += item.width;
+        position += item.width + gap.horizontal;
       }
       if (direction === 'y') {
-        position += item.height;
+        position += item.height + gap.vertical;
       }
     });
   }

--- a/addon/src/modifiers/sortable-item.ts
+++ b/addon/src/modifiers/sortable-item.ts
@@ -983,7 +983,7 @@ export default class SortableItemModifier<T> extends Modifier<SortableItemModifi
     let width = el.offsetWidth;
     const elStyles = getComputedStyle(el);
 
-    width += parseInt(elStyles.marginLeft) + parseInt(elStyles.marginRight); // equal to jQuery.outerWidth(true)
+    width += parseFloat(elStyles.marginLeft) + parseFloat(elStyles.marginRight); // equal to jQuery.outerWidth(true)
 
     width += getBorderSpacing(el).horizontal;
 
@@ -999,15 +999,18 @@ export default class SortableItemModifier<T> extends Modifier<SortableItemModifi
     const el = this.element;
     let height = el.offsetHeight;
     const elStyles = getComputedStyle(el);
+    const marginTop = parseFloat(elStyles.marginTop);
+    const marginBottom = parseFloat(elStyles.marginBottom);
 
-    // This is needed atm only for grid, to fix jumping on drag-start.
-    // In test-app it looks like there is a side-effect when we activate also for direction vertical.
-    // If any user will anytime report a jumping in vertical direction, we should activate for every direction and fix our test-app
-    if (this.direction === 'grid') {
-      height += parseFloat(elStyles.marginTop);
+    // Adjacent margins only collapse (to their max) in normal block flow;
+    // flex/grid parents (needed for `gap` support) keep both in full.
+    const parentDisplay = el.parentElement && getComputedStyle(el.parentElement).display;
+
+    if (parentDisplay === 'block') {
+      height += Math.max(marginTop, marginBottom);
+    } else {
+      height += marginTop + marginBottom;
     }
-
-    height += parseFloat(elStyles.marginBottom);
 
     height += getBorderSpacing(el).vertical;
 

--- a/addon/src/utils/css-calculation.ts
+++ b/addon/src/utils/css-calculation.ts
@@ -17,3 +17,23 @@ export function getBorderSpacing(el: Element) {
     vertical: parseFloat(vertical ?? ''),
   };
 }
+
+/**
+  Gets numeric `column-gap`/`row-gap` values for a given element.
+
+  @method getGap
+  @param {Element} element
+  @return {Object}
+  @private
+*/
+export function getGap(el: Element) {
+  const { columnGap, rowGap } = getComputedStyle(el);
+
+  const horizontal = parseFloat(columnGap); // '0px' or 'normal'
+  const vertical = parseFloat(rowGap); // '0px' or 'normal'
+
+  return {
+    horizontal: isNaN(horizontal) ? 0 : horizontal,
+    vertical: isNaN(vertical) ? 0 : vertical,
+  };
+}

--- a/docs/app/controllers/index.js
+++ b/docs/app/controllers/index.js
@@ -70,4 +70,10 @@ export default class ModifierController extends Controller {
     set(this, 'model.itemsGrid', newOrder);
     set(this, 'model.dragged', draggedModel);
   }
+
+  @action
+  updateGridGap(newOrder, draggedModel) {
+    set(this, 'model.itemsGridGap', newOrder);
+    set(this, 'model.dragged', draggedModel);
+  }
 }

--- a/docs/app/routes/index.js
+++ b/docs/app/routes/index.js
@@ -3,13 +3,16 @@ import Route from '@ember/routing/route';
 export default class Index extends Route {
   model() {
     const itemsGrid = [];
+    const itemsGridGap = [];
     for (let i = 1; i <= 26; i++) {
       itemsGrid.push(`Item ${i}`);
+      itemsGridGap.push(`Item ${i}`);
     }
 
     return {
       items: ['Zero', 'One', 'Two', 'Three', 'Four'],
       itemsGrid: itemsGrid,
+      itemsGridGap: itemsGridGap,
     };
   }
 }

--- a/docs/app/styles/app.css
+++ b/docs/app/styles/app.css
@@ -138,6 +138,32 @@
   z-index: 10;
 }
 
+.grid-gap-demo ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.grid-gap-demo .sortable-item {
+  width: 120px;
+  height: 120px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: move;
+  background-color: hsl(197deg 100% 45%);
+}
+
+.grid-gap-demo .sortable-item.is-dragging {
+  background: hsl(197deg 100% 35%);
+}
+
+.grid-gap-demo .sortable-item.is-dropping {
+  background: hsl(197deg 100% 40%);
+  z-index: 10;
+}
+
 .table-demo table {
   position: relative;
   border-collapse: separate;

--- a/docs/app/templates/index.hbs
+++ b/docs/app/templates/index.hbs
@@ -69,7 +69,7 @@
     </section>
     
     <section class='grid-demo'>
-      <h3>Grid</h3>
+      <h3>Grid (spacing via margin)</h3>
 
       <ol
         data-test-grid-demo-group
@@ -83,6 +83,27 @@
       >
         {{#each @model.itemsGrid as |item|~}}
           <li data-test-grid-demo-handle tabindex='0' {{sortable-item model=item groupName='grid'}}>
+            <ItemPresenter @item={{item}} />
+          </li>
+        {{~/each}}
+      </ol>
+    </section>
+
+    <section class='grid-gap-demo'>
+      <h3>Grid (spacing via `gap`, no margin)</h3>
+
+      <ol
+        data-test-grid-gap-demo-group
+        {{sortable-group
+          direction='grid'
+          onChange=this.updateGridGap
+          itemVisualClass=this.itemVisualClass
+          handleVisualClass=this.handleVisualClass
+          groupName='grid-gap'
+        }}
+      >
+        {{#each @model.itemsGridGap as |item|~}}
+          <li data-test-grid-gap-demo-handle tabindex='0' {{sortable-item model=item groupName='grid-gap'}}>
             <ItemPresenter @item={{item}} />
           </li>
         {{~/each}}

--- a/test-app/tests/acceptance/positioning-test.js
+++ b/test-app/tests/acceptance/positioning-test.js
@@ -1,0 +1,141 @@
+import { module, test } from 'qunit';
+import { visit, find } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { drag } from 'ember-sortable/test-support';
+
+async function assertPositionsStable(assert, itemElements) {
+  const initialPositions = new WeakMap();
+  const [firstElement] = itemElements;
+
+  itemElements.forEach((element) =>
+    initialPositions.set(element, element.getBoundingClientRect()),
+  );
+
+  await drag('mouse', firstElement, () => ({ dx: 20, dy: 20 }), {
+    beforedragend() {
+      itemElements.forEach((element) => {
+        const initialPosition = initialPositions.get(element);
+        const currentPosition = element.getBoundingClientRect();
+
+        if (element === firstElement) {
+          assert.notDeepEqual(
+            currentPosition,
+            initialPosition,
+            'the dragged item moved',
+          );
+        } else {
+          assert.deepEqual(
+            currentPosition,
+            initialPosition,
+            'the item did not move',
+          );
+        }
+      });
+    },
+  });
+}
+
+module('Acceptance | positioning with gap', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('correctly positions items vertically when there is no gap', async function (assert) {
+    assert.expect(5);
+
+    await visit('/');
+
+    const containerElement = find('[data-test-vertical-demo-group]');
+    const itemElements = Array.from(
+      containerElement.querySelectorAll(
+        '[data-test-vertical-demo-item] .handle',
+      ),
+    );
+
+    await assertPositionsStable(assert, itemElements);
+  });
+
+  test('correctly positions items vertically when there is a gap', async function (assert) {
+    assert.expect(5);
+
+    await visit('/');
+
+    const containerElement = find('[data-test-vertical-demo-group]');
+    const itemElements = Array.from(
+      containerElement.querySelectorAll(
+        '[data-test-vertical-demo-item] .handle',
+      ),
+    );
+
+    Object.assign(containerElement.style, {
+      display: 'grid',
+      rowGap: '20px',
+      columnGap: '10px',
+      gridTemplateColumns: '1fr',
+    });
+
+    await assertPositionsStable(assert, itemElements);
+  });
+
+  test('correctly positions items horizontally when there is no gap', async function (assert) {
+    assert.expect(5);
+
+    await visit('/');
+
+    const containerElement = find('[data-test-horizontal-demo-group]');
+    const itemElements = Array.from(
+      containerElement.querySelectorAll('[data-test-horizontal-demo-handle]'),
+    );
+
+    await assertPositionsStable(assert, itemElements);
+  });
+
+  test('correctly positions items horizontally when there is a gap', async function (assert) {
+    assert.expect(5);
+
+    await visit('/');
+
+    const containerElement = find('[data-test-horizontal-demo-group]');
+    const itemElements = Array.from(
+      containerElement.querySelectorAll('[data-test-horizontal-demo-handle]'),
+    );
+
+    Object.assign(containerElement.style, {
+      display: 'grid',
+      rowGap: '20px',
+      columnGap: '10px',
+      gridTemplateColumns: 'repeat(5, 1fr)',
+    });
+
+    await assertPositionsStable(assert, itemElements);
+  });
+
+  test('correctly positions items in a grid when there is no gap', async function (assert) {
+    assert.expect(26);
+
+    await visit('/');
+
+    const containerElement = find('[data-test-grid-demo-group]');
+    const itemElements = Array.from(
+      containerElement.querySelectorAll('[data-test-grid-demo-handle]'),
+    );
+
+    await assertPositionsStable(assert, itemElements);
+  });
+
+  test('correctly positions items in a grid when there is a gap', async function (assert) {
+    assert.expect(26);
+
+    await visit('/');
+
+    const containerElement = find('[data-test-grid-demo-group]');
+    const itemElements = Array.from(
+      containerElement.querySelectorAll('[data-test-grid-demo-handle]'),
+    );
+
+    Object.assign(containerElement.style, {
+      rowGap: '20px',
+      columnGap: '10px',
+    });
+
+    await assertPositionsStable(assert, itemElements);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #473.

`SortableGroupModifier#update` positions every item by accumulating each item's "outer size" (its own box plus margins, via `SortableItemModifier#width`/`#height`), with no concept of CSS `gap`. A container using `gap` for spacing instead of margins visibly collapses that gap during a drag: the accumulated position math doesn't reserve any room for it, so the `transform` applied to every non-dragged item ends up too tight relative to the real, gapped layout.

## Fix

- New `getGap(el)` helper in `utils/css-calculation.ts`, reading `column-gap`/`row-gap` via `getComputedStyle` (guarding the `'normal'` keyword, which parses to `NaN`, to `0`).
- `SortableGroupModifier#update` now adds the relevant gap (horizontal for `x`/`grid`, vertical for `y`, plus vertical for the grid direction's row-wrap height tracking) once per item into the position accumulation.
- `SortableItemModifier#height` now only collapses adjacent margins (takes the max of `marginTop`/`marginBottom`) when the parent is in normal block flow. Flex/grid parents — which `gap` support requires — don't collapse margins, so both need to count in full there. Previously this only ever added `marginBottom`, which happened to work out for the common block-flow case with symmetric margins, but isn't correct for a `gap`-based flex/grid layout with asymmetric margins.
- `SortableItemModifier#width`'s margin reads switched from `parseInt` to `parseFloat` (an adjacent precision fix from the same source patch, folded in since it touches the same lines).

I did not need to change `_move()` (the keyboard-reorder adjacent-item swap): the width/height-delta formula it uses to swap two items into each other's slots is unaffected by a constant `gap` term, since gap contributes identically regardless of which item occupies which slot — verified this algebraically before leaving it alone.

This is based on the approach from [`benedikt/ember-sortable#1`](https://github.com/benedikt/ember-sortable/pull/1), which implemented the same fix but was accidentally opened against a fork instead of upstream and never merged/redirected. I ported it to this repo's TypeScript source and converted its acceptance test.

## Test plan

- Added `test-app/tests/acceptance/positioning-test.js` (adapted from the referenced fork PR), asserting that every non-dragged item's `getBoundingClientRect()` stays pixel-identical mid-drag, in the `vertical`/`horizontal`/`grid` demos, both without and with an explicit `gap` applied to the container.
- Verified the three "with a gap" tests fail without this fix (reverting only the source changes) and pass with it; the three "no gap" tests pass either way.
- Full `pnpm test` in `test-app`: 49/49 passing.
- `pnpm lint` clean in both `addon` and `test-app`.
