### PR TITLE
fix: round position only at assignment to avoid subpixel item jitter

### DIFF
--- a/addon/src/modifiers/sortable-group.ts
+++ b/addon/src/modifiers/sortable-group.ts
@@ -772,11 +772,13 @@ export default class SortableGroupModifier<T> extends Modifier<SortableGroupModi
       }
 
       if (!isDestroyed(item) && !item.isDragging) {
+        // Round only at assignment to match offsetLeft/offsetTop's integer
+        // rounding, so undragged items don't jitter by a fractional pixel.
         if (direction === 'grid') {
-          item.x = position;
-          item.y = lastTopOffset;
+          item.x = Math.round(position);
+          item.y = Math.round(lastTopOffset);
         } else {
-          set(item, direction, position);
+          set(item, direction, Math.round(position));
         }
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #678/#679 — fixes the failing `positioning-test.js` case flagged in https://github.com/adopted-ember-addons/ember-sortable/actions/runs/32402402070/job/96534062089?pr=680.

#678 made `SortableItemModifier#width`/`#height` subpixel-precise (via `getBoundingClientRect()`) to fix a grid wrap-check drift bug. But `_applyPosition()` computes its transform delta by diffing the computed position against `offsetLeft`/`offsetTop`, which the browser always rounds to integers. That float-vs-integer mismatch caused non-dragged items to be assigned a slightly fractional target position and visibly jitter during a drag — caught by the "positioning with gap: correctly positions items horizontally when there is no gap" test.

I verified this is a bug in #678 itself, not something introduced only by combining with #679: porting the new test onto the #678 commit alone reproduces the same failure for the no-gap horizontal case.

The fix keeps the running position sum subpixel-precise internally (so the grid wrap-check from #678 stays correct), but rounds only at the point of assigning the final value to `item.x`/`item.y`, matching the integer precision of `offsetLeft`/`offsetTop`.

## Test plan
- [x] `pnpm test:ember` — all 50 tests pass, including the previously-failing `positioning-test.js` case and the grid-wrap regression test from #678